### PR TITLE
setup the very basics of a jupyter extension

### DIFF
--- a/bookstore/__init__.py
+++ b/bookstore/__init__.py
@@ -3,4 +3,6 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
+from .jupyter_server_extension import load_jupyter_server_extension, _jupyter_server_extension_paths
+
 from .archive import BookstoreContentsArchiver

--- a/bookstore/archive.py
+++ b/bookstore/archive.py
@@ -17,6 +17,11 @@ from traitlets import (
 class BookstoreContentsArchiver(ContentsManager, HasTraits):
     """
     Archives contents via one ContentsManager and passes through to
-    another ContentsManager
+    another ContentsManager.
+
+    Likely route:
+
+    * Write directly to S3 on post_save_hook
+
     """
     pass

--- a/bookstore/jupyter_server_extension/__init__.py
+++ b/bookstore/jupyter_server_extension/__init__.py
@@ -1,0 +1,4 @@
+from .handlers import load_jupyter_server_extension
+
+def _jupyter_server_extension_paths():
+    return [dict(module="bookstore")]

--- a/bookstore/jupyter_server_extension/handlers.py
+++ b/bookstore/jupyter_server_extension/handlers.py
@@ -1,0 +1,26 @@
+import json
+from notebook.utils import url_path_join
+from notebook.base.handlers import APIHandler, \
+    AuthenticatedFileHandler
+from tornado import web
+
+from .._version import get_versions
+version = get_versions()['version']
+
+class BookstoreVersionHandler(APIHandler):
+    """Returns the version of bookstore currently running. Used mostly to lay foundations
+    for this package though frontends can use this endpoint for feature detection.
+    """
+    @web.authenticated
+    def get(self):
+        self.finish(json.dumps({"bookstore": True, "version": version}))
+
+def load_jupyter_server_extension(nb_app):
+    web_app = nb_app.web_app
+    host_pattern = '.*$'
+    base_bookstore_pattern = url_path_join(web_app.settings['base_url'],
+                    '/api/bookstore')
+
+    web_app.add_handlers(host_pattern, [
+        (base_bookstore_pattern, BookstoreVersionHandler),
+    ])


### PR DESCRIPTION
Sets up bookstore as a jupyter extension. This will be used for new API endpoints as we need them for publishing, scheduling, and if we end up needing them for versioning.