### PR TITLE
Add sleep to loop for minio and jupyter to talk

### DIFF
--- a/ci/integration.js
+++ b/ci/integration.js
@@ -166,11 +166,12 @@ const main = async () => {
       nbformat_minor: 2,
       metadata: {}
     });
+    await sleep(100);
   }
 
   // Wait for minio to have the notebook
   // Future iterations of this script should poll to get the notebook
-  await sleep(1000);
+  await sleep(700);
 
   jupyterServer.shutdown();
 


### PR DESCRIPTION
Without this sleep on my local machine when running the ci
I would run into an error where by the time it was checking
for ci-local-writeout2.ipynb it had save: 2 not save: 3
according to minio.

Here is what the end of the error looked like: 

```
ci-local-writeout2.ipynb
{"cells": [], "nbformat": 4, "nbformat_minor": 2, "metadata": {"save": 2}}
original
{ cells: [],
  nbformat: 4,
  nbformat_minor: 2,
  metadata: { save: 3 } }
from s3
{ cells: [],
  nbformat: 4,
  nbformat_minor: 2,
  metadata: { save: 2 } }
unhandledRejection Error: Notebook on S3 does not match what we sent
    at compareNotebooks (/Users/mpacer/jupyter/bookstore/ci/integration.js:82:13)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
Error: Notebook on S3 does not match what we sent
    at compareNotebooks (/Users/mpacer/jupyter/bookstore/ci/integration.js:82:13)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:182:7)
```

I took time away from the out-of-loop sleep to account for the amount of time now taken inside the loop. 