### PR TITLE
refactors archive functionality to use aiobotocore & asyncio

### DIFF
--- a/bookstore/s3_paths.py
+++ b/bookstore/s3_paths.py
@@ -13,10 +13,11 @@ def s3_path(bucket, prefix, path=''):
     return _join(bucket, prefix, path)
 
 
+def s3_key(prefix, path=''):
+    """compute the s3 key based on the prefix, and the path to the notebook"""
+    return _join(prefix, path)
+
+
 def s3_display_path(bucket, prefix, path=''):
     """create a display name for use in logs"""
     return 's3://' + s3_path(bucket, prefix, path)
-
-
-print(s3_path('notebooks', 'workspace', 'test/what.ipynb'))
-print(s3_display_path('notebooks', 'workspace', 'test/what.ipynb'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ipython >= 5.0
 notebook
 s3fs
 tornado >= 5.1.1
+aiobotocore


### PR DESCRIPTION
It is remarkable how much nicer & cleaner this API is.

client.put_object seems to expect/allow json content encoded as a `str` (rather than requiring us to reëncode of json content back to `bytes`). I'm not sure if that's a good thing or a bad thing, but if it's a bad thing we need to probably update our tests to capture the case where that causes a problem. 