### PR TITLE
add simple validate_bookstore function & tests (not traitlets validate)

### DIFF
--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -39,6 +39,13 @@ class BookstoreSettings(LoggingConfigurable):
 
 
 def validate_bookstore(settings: BookstoreSettings):
+    """Test for establishing that bookstore has been appropriately set up.
+    
+    Parameters
+    ----------
+    settings: bookstore.bookstore_config.BookstoreSettings
+        The instantiated Settings object to be validated.
+    """
     valid_settings = [settings.workspace_prefix != "",
                       settings.published_prefix != "",
                       settings.s3_bucket != "",

--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -36,3 +36,12 @@ class BookstoreSettings(LoggingConfigurable):
         16,
         help="Maximum number of threads for the threadpool allocated for S3 read/writes",
     ).tag(config=True)
+
+
+def validate_bookstore(settings: BookstoreSettings):
+    valid_settings = [settings.workspace_prefix != "",
+                      settings.published_prefix != "",
+                      settings.s3_bucket != "",
+                      settings.s3_endpoint_url != "",
+                      ]
+    return all(valid_settings)

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -1,6 +1,13 @@
 """Tests for bookstore config"""
 import pytest
 
+from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 
-def test_bookstore_config():
-    pass
+
+def test_validate_bookstore_defaults():
+    settings = BookstoreSettings()
+    assert validate_bookstore(settings)
+
+def test_validate_bookstore_endpoint():
+    settings2 = BookstoreSettings(s3_endpoint_url="")
+    assert not validate_bookstore(settings2)

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -5,9 +5,30 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 
 
 def test_validate_bookstore_defaults():
+    """Tests that all bookstore validates with default values."""
     settings = BookstoreSettings()
     assert validate_bookstore(settings)
 
+
+def test_validate_bookstore_published():
+    """Tests that bookstore does not validate with an empty published_prefix."""
+    settings = BookstoreSettings(published_prefix="")
+    assert not validate_bookstore(settings)
+
+
+def test_validate_bookstore_workspace():
+    """Tests that bookstore does not validate with an empty workspace_prefix."""
+    settings = BookstoreSettings(workspace_prefix="")
+    assert not validate_bookstore(settings)
+
+
 def test_validate_bookstore_endpoint():
-    settings2 = BookstoreSettings(s3_endpoint_url="")
-    assert not validate_bookstore(settings2)
+    """Tests that bookstore does not validate with an empty s3_endpoint_url."""
+    settings = BookstoreSettings(s3_endpoint_url="")
+    assert not validate_bookstore(settings)
+
+
+def test_validate_bookstore_bucket():
+    """Tests that bookstore does not validate with an empty s3_bucket."""
+    settings = BookstoreSettings(s3_bucket="")
+    assert not validate_bookstore(settings)


### PR DESCRIPTION
@rgbkrkr asked to have a way to test for whether bookstore is properly configured over in the nteract_on_jupyter handler.

I felt like the business logic for that should live in the bookstore repo… seemed like the best way to do that would be to expose a validation function.

Since it requires that a collection of values are set appropriately, I figured it was going to be more straightforward to write a quick function rather than define custom validation functions for each one of the traitlets in question.

In the long run, we might want to go in the traitlets direction… but, for now, this seemed like a good way to delay validation and expose it to another library.