### PR TITLE
Add detail to archive docstrings and Sphinx docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 Oh, hello there! You're probably reading this because you are interested in
 contributing to nteract. That's great to hear! This document will help you
 through your journey of open source. Love it, cherish it, take it out to

--- a/bookstore/archive.py
+++ b/bookstore/archive.py
@@ -77,8 +77,8 @@ class BookstoreContentsArchiver(FileContentsManager):
         allowed to a path if a valid path_lock is held and the path is not
         locked by another process.
 
-        Attribute
-        ---------
+        Parameters
+        ----------
         record : ArchiveRecord
             A notebook and where it should be written to storage
         """
@@ -121,8 +121,8 @@ class BookstoreContentsArchiver(FileContentsManager):
         When the event loop is available for execution of the request, the
         storage of the notebook will be done and the write to storage occurs.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         model : str
             The type of file
         path : str

--- a/bookstore/archive.py
+++ b/bookstore/archive.py
@@ -42,8 +42,9 @@ class BookstoreContentsArchiver(FileContentsManager):
     path_lock_ready: ayncio mutex lock
         A mutex lock associated with a path
 
-    See also:
-        https://jupyter-notebook.readthedocs.io/en/stable/extending/contents.html#contents-api
+    See also
+    --------
+    https://jupyter-notebook.readthedocs.io/en/stable/extending/contents.html#contents-api
     """
     def __init__(self, *args, **kwargs):
         super(FileContentsManager, self).__init__(*args, **kwargs)

--- a/bookstore/archive.py
+++ b/bookstore/archive.py
@@ -28,8 +28,11 @@ class BookstoreContentsArchiver(FileContentsManager):
         # opt ourselves into being part of the Jupyter App that should have Bookstore Settings applied
         self.settings = BookstoreSettings(parent=self)
 
-        self.log.info("Archiving notebooks to {}".format(s3_display_path(
-            self.settings.s3_bucket, self.settings.workspace_prefix)))
+        self.log.info(
+            "Archiving notebooks to {}".format(
+                s3_display_path(self.settings.s3_bucket, self.settings.workspace_prefix)
+            )
+        )
 
         self.session = aiobotocore.get_session()
 
@@ -55,23 +58,23 @@ class BookstoreContentsArchiver(FileContentsManager):
 
         async with lock:
             try:
-                async with self.session.create_client('s3',
-                                                      aws_secret_access_key=self.settings.s3_secret_access_key,
-                                                      aws_access_key_id=self.settings.s3_access_key_id,
-                                                      endpoint_url=self.settings.s3_endpoint_url,
-                                                      region_name=self.settings.s3_region_name,
-                                                      ) as client:
+                async with self.session.create_client(
+                    's3',
+                    aws_secret_access_key=self.settings.s3_secret_access_key,
+                    aws_access_key_id=self.settings.s3_access_key_id,
+                    endpoint_url=self.settings.s3_endpoint_url,
+                    region_name=self.settings.s3_region_name,
+                ) as client:
                     self.log.info("Processing storage write of %s", record.filepath)
                     file_key = s3_key(self.settings.workspace_prefix, record.filepath)
-                    await client.put_object(Bucket=self.settings.s3_bucket, Key=file_key, Body=record.content)
+                    await client.put_object(
+                        Bucket=self.settings.s3_bucket, Key=file_key, Body=record.content
+                    )
                     self.log.info("Done with storage write of %s", record.filepath)
             except Exception as e:
-                    self.log.error(
-                        'Error while archiving file: %s %s',
-                        record.filepath,
-                        e,
-                        exc_info=True,
-                    )
+                self.log.error(
+                    'Error while archiving file: %s %s', record.filepath, e, exc_info=True
+                )
 
     def run_pre_save_hook(self, model, path, **kwargs):
         """Store notebook to S3 when saves happen
@@ -87,8 +90,6 @@ class BookstoreContentsArchiver(FileContentsManager):
         loop.spawn_callback(
             self.archive,
             ArchiveRecord(
-                content=content,
-                filepath=path,
-                queued_time=ioloop.IOLoop.current().time(),
+                content=content, filepath=path, queued_time=ioloop.IOLoop.current().time()
             ),
         )

--- a/bookstore/archive.py
+++ b/bookstore/archive.py
@@ -23,16 +23,17 @@ class ArchiveRecord(NamedTuple):
 
 
 class BookstoreContentsArchiver(FileContentsManager):
-    """Archives notebooks to storage (S3) on save by UI or parameterized workflow
+    """Archives notebooks to storage (S3) on notebook save
 
     This class is a custom Jupyter `FileContentsManager` which holds information
     on storage location, path to it, and file to be written there.
 
     Bookstore settings combine with the parent Jupyter application settings.
-
+``
     A session is created for the current event loop. To write to a particular
     path on S3, acquire a lock. After acquiring the lock, `archive`
     authenticates using the storage service's credentials. If allowed, the
+
     notebook is queued to be written to storage (i.e. S3).
 
     Attributes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../CHANGELOG.md

--- a/docs/source/code_of_conduct.rst
+++ b/docs/source/code_of_conduct.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../CODE_OF_CONDUCT.md

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ import sys
 
 import m2r
 
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../..'))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,7 +40,13 @@ release = '0.2.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.mathjax', 'm2r']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.napoleon',
+    'm2r'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,0 +1,32 @@
+Configuration
+=============
+
+
+Settings in config file
+-----------------------
+
+`~/.jupyter/jupyter_notebook_config.py` can store commonly used settings for
+bookstore. Bookstore settings including the workspace and published location
+for notebooks. Additionally, AWS credentials for S3 may also be added.
+
+
+```python
+# jupyter config
+# At ~/.jupyter/jupyter_notebook_config.py for user installs on macOS
+# See https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html for other places to plop this
+
+from bookstore import BookstoreContentsArchiver
+
+c.NotebookApp.contents_manager_class = BookstoreContentsArchiver
+
+# All Bookstore settings are centralized on one config object so you don't have to configure it for each class
+c.BookstoreSettings.workspace_prefix = "/workspace/kylek/notebooks"
+c.BookstoreSettings.published_prefix = "/published/kylek/notebooks"
+
+c.BookstoreSettings.s3_bucket = "<bucket-name>"
+
+# Note: if bookstore is used from an EC2 instance with the right IAM role, you don't
+# have to specify these
+c.BookstoreSettings.s3_access_key_id = <AWS Access Key ID / IAM Access Key ID>
+c.BookstoreSettings.s3_secret_access_key = <AWS Secret Access Key / IAM Secret Access Key>
+```

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -5,7 +5,7 @@ Configuration
 Bookstore ettings in Jupyter configuration file
 -----------------------------------------------
 
-`~/.jupyter/jupyter_notebook_config.py` can store commonly used settings for
+``~/.jupyter/jupyter_notebook_config.py`` can store commonly used settings for
 bookstore. Bookstore settings include:
 
     - the workspace and published storage location

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2,15 +2,20 @@ Configuration
 =============
 
 
-Bookstore ettings in Jupyter configuration file
------------------------------------------------
+Bookstore settings in Jupyter configuration file
+------------------------------------------------
 
-``~/.jupyter/jupyter_notebook_config.py`` can store commonly used settings for
-bookstore. Bookstore settings include:
+``BookstoreSettings`` can store commonly used settings for
+bookstore. These settings include:
 
     - the workspace and published storage location
     - S3 bucket information
     - AWS credentials for S3 may also be addeds
+
+Examples
+~~~~~~~~
+
+What follows is an example of this in the ``~/.jupyter/jupyter_notebook_config.py`` file:
 
 .. code-block:: python
 
@@ -34,3 +39,6 @@ bookstore. Bookstore settings include:
     c.BookstoreSettings.s3_access_key_id = <AWS Access Key ID / IAM Access Key ID>
     c.BookstoreSettings.s3_secret_access_key = <AWS Secret Access Key / IAM Secret Access Key>
 
+
+An example of using BookstoreSettings in the ``~/jupyter/jupyter_config.py`` file can be found in the root directory
+of bookstore's GitHub repo.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -2,31 +2,35 @@ Configuration
 =============
 
 
-Settings in config file
------------------------
+Bookstore ettings in Jupyter configuration file
+-----------------------------------------------
 
 `~/.jupyter/jupyter_notebook_config.py` can store commonly used settings for
-bookstore. Bookstore settings including the workspace and published location
-for notebooks. Additionally, AWS credentials for S3 may also be added.
+bookstore. Bookstore settings include:
+
+    - the workspace and published storage location
+    - S3 bucket information
+    - AWS credentials for S3 may also be addeds
+
+.. code-block:: python
+
+    """jupyter config
+    # At ~/.jupyter/jupyter_notebook_config.py for user installs on macOS
+    # See https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html for other places to plop this
+    """
+    from bookstore import BookstoreContentsArchiver
 
 
-```python
-# jupyter config
-# At ~/.jupyter/jupyter_notebook_config.py for user installs on macOS
-# See https://jupyter.readthedocs.io/en/latest/projects/jupyter-directories.html for other places to plop this
+    c.NotebookApp.contents_manager_class = BookstoreContentsArchiver
 
-from bookstore import BookstoreContentsArchiver
+    # All Bookstore settings are centralized on one config object so you don't have to configure it for each class
+    c.BookstoreSettings.workspace_prefix = "/workspace/kylek/notebooks"
+    c.BookstoreSettings.published_prefix = "/published/kylek/notebooks"
 
-c.NotebookApp.contents_manager_class = BookstoreContentsArchiver
+    c.BookstoreSettings.s3_bucket = "<bucket-name>"
 
-# All Bookstore settings are centralized on one config object so you don't have to configure it for each class
-c.BookstoreSettings.workspace_prefix = "/workspace/kylek/notebooks"
-c.BookstoreSettings.published_prefix = "/published/kylek/notebooks"
+    # Note: if bookstore is used from an EC2 instance with the right IAM role, you don't
+    # have to specify these
+    c.BookstoreSettings.s3_access_key_id = <AWS Access Key ID / IAM Access Key ID>
+    c.BookstoreSettings.s3_secret_access_key = <AWS Secret Access Key / IAM Secret Access Key>
 
-c.BookstoreSettings.s3_bucket = "<bucket-name>"
-
-# Note: if bookstore is used from an EC2 instance with the right IAM role, you don't
-# have to specify these
-c.BookstoreSettings.s3_access_key_id = <AWS Access Key ID / IAM Access Key ID>
-c.BookstoreSettings.s3_secret_access_key = <AWS Secret Access Key / IAM Secret Access Key>
-```

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../CONTRIBUTING.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,17 +3,21 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+bookstore
+=========
+
 .. mdinclude:: ../../README.md
 
-.. toctree::
-   :maxdepth: 1
-   :caption: Contents:
+Table of Contents
+=================
 
-   reference/modules
-   contributing
-   code_of_conduct
-   releasing
-   changelog
+.. toctree::
+   :maxdepth: 2
+
+   reference/bookstore
+   project/index
+
+
 
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,9 @@ Table of Contents
 .. toctree::
    :maxdepth: 2
 
+   installation
+   configuration
+   usage
    reference/bookstore
    project/index
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@
    :maxdepth: 1
    :caption: Contents:
 
+   reference/modules
    contributing
    code_of_conduct
    releasing

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,8 @@
 bookstore
 =========
 
-.. mdinclude:: ../../README.md
+**bookstore** provides tooling and workflow recommendations for storing, scheduling, and publishing notebooks.
+
 
 Table of Contents
 =================
@@ -19,8 +20,6 @@ Table of Contents
    usage
    reference/bookstore
    project/index
-
-
 
 
 Indices and tables

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,0 +1,41 @@
+Installation
+============
+
+bookstore supports installation on Python 3.6 and above. Processes notebooks from Python 2 or Python 3.
+
+Install from PyPI
+-----------------
+
+.. code-block:: bash
+
+    python3 -m pip install bookstore
+
+Install from Source
+-------------------
+
+1. Clone this repo:
+
+    .. code-block:: bash
+
+        git clone https://github.com/nteract/bookstore.git
+
+2. Change directory to repo root:
+
+    .. code-block:: bash
+
+        cd bookstore
+
+3. Install dependencies:
+
+    .. code-block:: bash
+
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install -r requirements-dev.txt
+
+4. Install package from source:
+
+    .. code-block:: bash
+
+        python3 -m pip install .
+
+    .. tip:: Don't forget the dot at the end of the command

--- a/docs/source/project/changelog.rst
+++ b/docs/source/project/changelog.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../../CHANGELOG.md

--- a/docs/source/project/code_of_conduct.rst
+++ b/docs/source/project/code_of_conduct.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../../CODE_OF_CONDUCT.md

--- a/docs/source/project/contributing.rst
+++ b/docs/source/project/contributing.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../../CONTRIBUTING.md

--- a/docs/source/project/index.rst
+++ b/docs/source/project/index.rst
@@ -1,0 +1,10 @@
+Project Documentation
+=====================
+
+.. toctree::
+   :maxdepth: 1
+
+   contributing
+   code_of_conduct
+   releasing
+   changelog

--- a/docs/source/project/releasing.rst
+++ b/docs/source/project/releasing.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../../RELEASING.md

--- a/docs/source/reference/archive.rst
+++ b/docs/source/reference/archive.rst
@@ -1,0 +1,7 @@
+bookstore.archive module
+========================
+
+.. automodule:: bookstore.archive
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/reference/bookstore.rst
+++ b/docs/source/reference/bookstore.rst
@@ -1,35 +1,10 @@
-bookstore package
-=================
+bookstore Reference
+===================
 
+.. toctree::
+   :maxdepth: 4
 
-bookstore.archive module
---------------------
-
-.. automodule:: bookstore.archive
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-bookstore.bookstore_config module
----------------------------------
-
-.. automodule:: bookstore.bookstore_config
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-bookstore.handlers module
--------------------------
-
-.. automodule:: bookstore.handlers
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-bookstore.s3_paths module
--------------------------
-
-.. automodule:: bookstore.s3_paths
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   archive
+   bookstore_config
+   handlers
+   s3_paths

--- a/docs/source/reference/bookstore.rst
+++ b/docs/source/reference/bookstore.rst
@@ -1,0 +1,35 @@
+bookstore package
+=================
+
+
+bookstore.archive module
+--------------------
+
+.. automodule:: bookstore.archive
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+bookstore.bookstore_config module
+---------------------------------
+
+.. automodule:: bookstore.bookstore_config
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+bookstore.handlers module
+-------------------------
+
+.. automodule:: bookstore.handlers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+bookstore.s3_paths module
+-------------------------
+
+.. automodule:: bookstore.s3_paths
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/reference/bookstore_config.rst
+++ b/docs/source/reference/bookstore_config.rst
@@ -1,0 +1,7 @@
+bookstore.bookstore_config module
+=================================
+
+.. automodule:: bookstore.bookstore_config
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/reference/handlers.rst
+++ b/docs/source/reference/handlers.rst
@@ -1,0 +1,7 @@
+bookstore.handlers module
+=========================
+
+.. automodule:: bookstore.handlers
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -1,7 +1,0 @@
-bookstore
-=========
-
-.. toctree::
-   :maxdepth: 4
-
-   bookstore

--- a/docs/source/reference/modules.rst
+++ b/docs/source/reference/modules.rst
@@ -1,0 +1,7 @@
+bookstore
+=========
+
+.. toctree::
+   :maxdepth: 4
+
+   bookstore

--- a/docs/source/reference/s3_paths.rst
+++ b/docs/source/reference/s3_paths.rst
@@ -1,0 +1,7 @@
+bookstore.s3_paths module
+=========================
+
+.. automodule:: bookstore.s3_paths
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/releasing.rst
+++ b/docs/source/releasing.rst
@@ -1,1 +1,0 @@
-.. mdinclude:: ../../RELEASING.md

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -15,17 +15,17 @@ Storage Paths
 All notebooks are archived to a single versioned S3 bucket with specific **prefixes** denoting the lifecycle of
 the notebook. For example:
 
-- `/workspace` - where users edit
-- `/published` - public notebooks (to an organization)
+- ``/workspace`` - where users edit
+- ``/published`` - public notebooks (to an organization)
 
 Each notebook path is a namespace that an external service ties into the schedule. We archive off versions,
 keeping the path intact (until a user changes them). For example, the prefixes that could be associated with
 storage types:
 
-- Notebook in "draft" form: `/workspace/kylek/notebooks/mine.ipynb`
-- Most recent published copy of a notebook: `/published/kylek/notebooks/mine.ipynb`
+- Notebook in "draft" form: ``/workspace/kylek/notebooks/mine.ipynb``
+- Most recent published copy of a notebook: ``/published/kylek/notebooks/mine.ipynb``
 
-Scheduled notebooks will also be referred to by the notebook `key`. In addition, we'll need to be able to surface
+Scheduled notebooks will also be referred to by the notebook ``key``. In addition, we'll need to be able to surface
 version IDs as well.
 
 Transitioning to this Storage Plan
@@ -37,11 +37,11 @@ Storage (writing on save using a ``post_save_hook`` for a Jupyter contents manag
 Publishing
 ----------
 
-The bookstore publishing endpoint is a `serverextension` to the classic Jupyter server. This means if you are
+The bookstore publishing endpoint is a ``serverextension`` to the classic Jupyter server. This means if you are
 developing this you will need to explicitly enable it to use the endpoint.
 
-To do so you run: `jupyter serverextension enable --py bookstore`.
+To do so you run: ``jupyter serverextension enable --py bookstore``.
 
 If you wish to enable it only for your current environment, run:
 
-`jupyter serverextension enable --py bookstore --sys-prefix`.
+``jupyter serverextension enable --py bookstore --sys-prefix``.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,47 @@
+Usage
+=====
+
+Automatic Notebook Versioning
+-----------------------------
+
+Every *save* of a notebook creates an *immutable copy* of the notebook on object storage.
+
+To simplify implementation, we currently rely on S3 as the object store, using
+`versioned buckets <https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html>`_.
+
+Storage Paths
+-------------
+
+All notebooks are archived to a single versioned S3 bucket with specific **prefixes** denoting the lifecycle of
+the notebook. For example:
+
+- `/workspace` - where users edit
+- `/published` - public notebooks (to an organization)
+
+Each notebook path is a namespace that an external service ties into the schedule. We archive off versions,
+keeping the path intact (until a user changes them). For example, the prefixes that could be associated with
+storage types:
+
+- Notebook in "draft" form: `/workspace/kylek/notebooks/mine.ipynb`
+- Most recent published copy of a notebook: `/published/kylek/notebooks/mine.ipynb`
+
+Scheduled notebooks will also be referred to by the notebook `key`. In addition, we'll need to be able to surface
+version IDs as well.
+
+Transitioning to this Storage Plan
+----------------------------------
+
+Since most people are on a regular filesystem, we'll start with writing to the `/workspace` prefix as Archival
+Storage (writing on save using a ``post_save_hook`` for a Jupyter contents manager).
+
+Publishing
+----------
+
+The bookstore publishing endpoint is a `serverextension` to the classic Jupyter server. This means if you are
+developing this you will need to explicitly enable it to use the endpoint.
+
+To do so you run: `jupyter serverextension enable --py bookstore`.
+
+If you wish to enable it only for your current environment, run:
+
+`jupyter serverextension enable --py bookstore --sys-prefix`.


### PR DESCRIPTION
- edits `archive.py` docstrings
- proposes changing `ability_to_create_path_lock` to `path_lock_ready`
- Autodoc all source files for Sphinx 

[Rendered docs](https://test-bookstore.readthedocs.io/en/archive-update/index.html)