### PR TITLE
Cleanup settings validation

### DIFF
--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -28,7 +28,7 @@ class BookstoreSettings(LoggingConfigurable):
     s3_region_name = Unicode("us-east-1", help="Region name").tag(
         config=True, env="JPYNB_S3_REGION_NAME"
     )
-    s3_bucket = Unicode("bookstore", help="Bucket name to store notebooks").tag(
+    s3_bucket = Unicode("", help="Bucket name to store notebooks").tag(
         config=True, env="JPYNB_S3_BUCKET"
     )
 

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -7,7 +7,7 @@ from notebook.utils import url_path_join
 from tornado import web
 
 from ._version import __version__, version_info
-from .bookstore_config import BookstoreSettings
+from .bookstore_config import BookstoreSettings, validate_bookstore
 from .s3_paths import s3_path, s3_key, s3_display_path
 
 
@@ -99,11 +99,12 @@ def load_jupyter_server_extension(nb_app):
     web_app = nb_app.web_app
     host_pattern = '.*$'
     base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
-
+    
     # Always enable the version handler
     web_app.add_handlers(host_pattern, [(base_bookstore_pattern, BookstoreVersionHandler)])
+    bookstore_settings = BookstoreSettings(parent=nb_app)
 
-    if not nb_app.config.get("BookstoreSettings"):
+    if not validate_bookstore(bookstore_settings):
         nb_app.log.info("Not enabling bookstore publishing since bookstore endpoint not configured")
     else:
         web_app.add_handlers(

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -21,7 +21,9 @@ class BookstoreVersionHandler(APIHandler):
 
     @web.authenticated
     def get(self):
-        self.finish(json.dumps({"bookstore": True, "version": version}))
+        self.finish(json.dumps({"bookstore": True,
+                                "version": version,
+                                "bookstore_validated": self.settings['bookstore_validated']}))
 
 
 # NOTE: We need to ensure that publishing is not configured if bookstore settings are not
@@ -32,8 +34,7 @@ class BookstoreVersionHandler(APIHandler):
 class BookstorePublishHandler(APIHandler):
     """Publish a notebook to the publish path"""
 
-    def __init__(self, *args, **kwargs):
-        super(APIHandler, self).__init__(*args, **kwargs)
+    def initialize(self):
         # create an easy helper to get at our bookstore settings quickly
         self.bookstore_settings = BookstoreSettings(config=self.config)
 
@@ -98,15 +99,20 @@ class BookstorePublishHandler(APIHandler):
 def load_jupyter_server_extension(nb_app):
     web_app = nb_app.web_app
     host_pattern = '.*$'
-    base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
     
     # Always enable the version handler
+    base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
     web_app.add_handlers(host_pattern, [(base_bookstore_pattern, BookstoreVersionHandler)])
     bookstore_settings = BookstoreSettings(parent=nb_app)
+    web_app.settings['bookstore_validated'] = validate_bookstore(bookstore_settings)
+                                               # and nb_app.nbserver_extensions.get("bookstore")
+                                               # need to delay adding this check until server
+                                               # has been updated
 
-    if not validate_bookstore(bookstore_settings):
-        nb_app.log.info("Not enabling bookstore publishing since bookstore endpoint not configured")
+    if not web_app.settings['bookstore_validated']:
+        nb_app.log.info("[bookstore] Not enabling bookstore publishing, endpoint not configured")
     else:
+        nb_app.log.info(f"[bookstore] Enabling bookstore publishing, version: {version}")
         web_app.add_handlers(
             host_pattern,
             [

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -7,7 +7,7 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 def test_validate_bookstore_defaults():
     """Tests that all bookstore validates with default values."""
     settings = BookstoreSettings()
-    assert validate_bookstore(settings)
+    assert not validate_bookstore(settings)
 
 
 def test_validate_bookstore_published():
@@ -30,5 +30,5 @@ def test_validate_bookstore_endpoint():
 
 def test_validate_bookstore_bucket():
     """Tests that bookstore does not validate with an empty s3_bucket."""
-    settings = BookstoreSettings(s3_bucket="")
-    assert not validate_bookstore(settings)
+    settings = BookstoreSettings(s3_bucket="A_bucket")
+    assert validate_bookstore(settings)

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -38,7 +38,8 @@ class JupyterServer {
         `--NotebookApp.token=${this.token}`,
         `--NotebookApp.disable_check_xsrf=True`,
         `--port=${this.port}`,
-        `--ip=${this.ip}`
+        `--ip=${this.ip}`,
+        `--log-level=10`
       ],
       { cwd: this.cwd }
     );


### PR DESCRIPTION
This does a little bit of a few things:

- makes it so settings don't validate by default (you need to know what your s3_bucket is even if you are using IAM roles)
- switch to using initialize rather than __init__ for the handler
- adds validation info onto base `api/bookstore/` endpoint
- changes logging level for testing so we see more info about the server