### PR TITLE
Add aioboto3 dependency and float up aiobotocore

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,11 +1,13 @@
 name: bookstore
 type: sphinx
 requirements_file: docs/requirements-doc.txt
+build:
+  image: latest
 python:
-  version: 3
+  version: 3.6
+  setup_py_install: true
 formats:
   - htmlzip
   - epub
-  # pdf disabled due to bug in sphinx 1.8 + recommonmark
-  # - pdf
+  - pdf
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ ipython >= 5.0
 notebook
 s3fs
 tornado >= 5.1.1
+aioboto3
 aiobotocore>=0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ipython >= 5.0
 notebook
 s3fs
 tornado >= 5.1.1
-aiobotocore==0.10.0
+aiobotocore>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'notebook',
         's3fs',
         'tornado >= 5.1.1',
-        'aiobotocore==0.10.0',
+        'aiobotocore>=0.10.0',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         's3fs',
         'tornado >= 5.1.1',
         'aiobotocore>=0.10.0',
+        'aioboto3',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
- Adds the [aioboto3](https://pypi.org/project/aioboto3/) package which when installed after aiobotocore resolves the boto3 dependency conflict since aioboto3 is a wrapper around boto3 and aiobotocore
- Build docs from latest RTD image so we can use Python 3.6