### PR TITLE
change API for validation to return an dict with feature specific checks

### DIFF
--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -76,22 +76,15 @@ def validate_bookstore(settings: BookstoreSettings):
         The instantiated Settings object to be validated.
     """
 
-    general_settings = [
-        settings.s3_bucket != "",
-        settings.s3_endpoint_url != "",
-    ]
+    general_settings = [settings.s3_bucket != "", settings.s3_endpoint_url != ""]
 
-    archive_settings = [
-        settings.workspace_prefix != "",
-    ]
+    archive_settings = [settings.workspace_prefix != ""]
 
-    published_settings = [
-        settings.published_prefix != ""
-    ]
+    published_settings = [settings.published_prefix != ""]
 
     validation_checks = {
-        "bookstore_validation": all(general_settings), 
-        "archive_validation": all(archive_settings),
-        "published_validation": all(published_settings),
+        "bookstore_valid": all(general_settings),
+        "archive_valid": all(archive_settings),
+        "publish_valid": all(published_settings),
     }
     return validation_checks

--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -75,10 +75,23 @@ def validate_bookstore(settings: BookstoreSettings):
     settings: bookstore.bookstore_config.BookstoreSettings
         The instantiated Settings object to be validated.
     """
-    valid_settings = [
-        settings.workspace_prefix != "",
-        settings.published_prefix != "",
+
+    general_settings = [
         settings.s3_bucket != "",
         settings.s3_endpoint_url != "",
     ]
-    return all(valid_settings)
+
+    archive_settings = [
+        settings.workspace_prefix != "",
+    ]
+
+    published_settings = [
+        settings.published_prefix != ""
+    ]
+
+    validation_checks = {
+        "bookstore_validation": all(general_settings), 
+        "archive_validation": all(archive_settings),
+        "published_validation": all(published_settings),
+    }
+    return validation_checks

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -26,7 +26,7 @@ class BookstoreVersionHandler(APIHandler):
                 {
                     "bookstore": True,
                     "version": version,
-                    "bookstore_validated": self.settings['bookstore_validated'],
+                    "bookstore_validation": self.settings['bookstore_validation'],
                 }
             )
         )
@@ -110,16 +110,16 @@ def load_jupyter_server_extension(nb_app):
     base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
     web_app.add_handlers(host_pattern, [(base_bookstore_pattern, BookstoreVersionHandler)])
     bookstore_settings = BookstoreSettings(parent=nb_app)
-    web_app.settings['bookstore_validated'] = validate_bookstore(bookstore_settings)
+    web_app.settings['bookstore_validation'] = validate_bookstore(bookstore_settings)
     # and nb_app.nbserver_extensions.get("bookstore")
     # need to delay adding this check until server
     # has been updated
 
-    check_published = [ 
-        web_app.settings['bookstore_validated'].get("bookstore_validation"),
-        web_app.settings['bookstore_validated'].get("published_validation"),
+    check_published = [
+        web_app.settings['bookstore_validation'].get("bookstore_valid"),
+        web_app.settings['bookstore_validation'].get("publish_valid"),
     ]
-    
+
     if not all(check_published):
         nb_app.log.info("[bookstore] Not enabling bookstore publishing, endpoint not configured")
     else:

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -115,7 +115,12 @@ def load_jupyter_server_extension(nb_app):
     # need to delay adding this check until server
     # has been updated
 
-    if not web_app.settings['bookstore_validated']:
+    check_published = [ 
+        web_app.settings['bookstore_validated'].get("bookstore_validation"),
+        web_app.settings['bookstore_validated'].get("published_validation"),
+    ]
+    
+    if not all(check_published):
         nb_app.log.info("[bookstore] Not enabling bookstore publishing, endpoint not configured")
     else:
         nb_app.log.info(f"[bookstore] Enabling bookstore publishing, version: {version}")

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -7,28 +7,30 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 def test_validate_bookstore_defaults():
     """Tests that all bookstore validates with default values."""
     settings = BookstoreSettings()
-    assert not validate_bookstore(settings)
+    assert not validate_bookstore(settings)['bookstore_validation']
+    assert validate_bookstore(settings)['published_validation']
+    assert validate_bookstore(settings)['archive_validation']
 
 
 def test_validate_bookstore_published():
     """Tests that bookstore does not validate with an empty published_prefix."""
     settings = BookstoreSettings(published_prefix="")
-    assert not validate_bookstore(settings)
+    assert not validate_bookstore(settings)['published_validation']
 
 
 def test_validate_bookstore_workspace():
     """Tests that bookstore does not validate with an empty workspace_prefix."""
     settings = BookstoreSettings(workspace_prefix="")
-    assert not validate_bookstore(settings)
+    assert not validate_bookstore(settings)['archive_validation']
 
 
 def test_validate_bookstore_endpoint():
     """Tests that bookstore does not validate with an empty s3_endpoint_url."""
     settings = BookstoreSettings(s3_endpoint_url="")
-    assert not validate_bookstore(settings)
+    assert not validate_bookstore(settings)['bookstore_validation']
 
 
 def test_validate_bookstore_bucket():
     """Tests that bookstore does not validate with an empty s3_bucket."""
     settings = BookstoreSettings(s3_bucket="A_bucket")
-    assert validate_bookstore(settings)
+    assert validate_bookstore(settings)['bookstore_validation']

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -7,30 +7,30 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 def test_validate_bookstore_defaults():
     """Tests that all bookstore validates with default values."""
     settings = BookstoreSettings()
-    assert not validate_bookstore(settings)['bookstore_validation']
-    assert validate_bookstore(settings)['published_validation']
-    assert validate_bookstore(settings)['archive_validation']
+    assert not validate_bookstore(settings)['bookstore_valid']
+    assert validate_bookstore(settings)['publish_valid']
+    assert validate_bookstore(settings)['archive_valid']
 
 
 def test_validate_bookstore_published():
     """Tests that bookstore does not validate with an empty published_prefix."""
     settings = BookstoreSettings(published_prefix="")
-    assert not validate_bookstore(settings)['published_validation']
+    assert not validate_bookstore(settings)['publish_valid']
 
 
 def test_validate_bookstore_workspace():
     """Tests that bookstore does not validate with an empty workspace_prefix."""
     settings = BookstoreSettings(workspace_prefix="")
-    assert not validate_bookstore(settings)['archive_validation']
+    assert not validate_bookstore(settings)['archive_valid']
 
 
 def test_validate_bookstore_endpoint():
     """Tests that bookstore does not validate with an empty s3_endpoint_url."""
     settings = BookstoreSettings(s3_endpoint_url="")
-    assert not validate_bookstore(settings)['bookstore_validation']
+    assert not validate_bookstore(settings)['bookstore_valid']
 
 
 def test_validate_bookstore_bucket():
     """Tests that bookstore does not validate with an empty s3_bucket."""
     settings = BookstoreSettings(s3_bucket="A_bucket")
-    assert validate_bookstore(settings)['bookstore_validation']
+    assert validate_bookstore(settings)['bookstore_valid']


### PR DESCRIPTION
Per conversation with @stormpython about feature specific config and settling on an API as soon as possible, this switches over the current validation code over to returning a dict (object once converted to json).

- "bookstore_validation" Checks whether bookstore overall has been 
validated (is false by default unless you set a s3_bucket)
- "archive_validation" Checks whether archiving has been configured
- "published_validation" Checks whether publishing has been configured