### PR TITLE
switches from storing the validation to storing bookstore settings

### DIFF
--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -21,7 +21,15 @@ class BookstoreVersionHandler(APIHandler):
 
     @web.authenticated
     def get(self):
-        self.finish(json.dumps({"bookstore": True, **self.settings['bookstore']}))
+        self.finish(
+            json.dumps(
+                {
+                    "bookstore": True,
+                    "version": self.settings['bookstore']["version"],
+                    "validation": self.settings['bookstore']["validation"],
+                }
+            )
+        )
 
 
 # NOTE: We need to ensure that publishing is not configured if bookstore settings are not

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -25,8 +25,7 @@ class BookstoreVersionHandler(APIHandler):
             json.dumps(
                 {
                     "bookstore": True,
-                    "version": version,
-                    "bookstore_validation": self.settings['bookstore_validation'],
+                    **self.settings['bookstore']
                 }
             )
         )
@@ -110,14 +109,14 @@ def load_jupyter_server_extension(nb_app):
     base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
     web_app.add_handlers(host_pattern, [(base_bookstore_pattern, BookstoreVersionHandler)])
     bookstore_settings = BookstoreSettings(parent=nb_app)
-    web_app.settings['bookstore_validation'] = validate_bookstore(bookstore_settings)
-    # and nb_app.nbserver_extensions.get("bookstore")
-    # need to delay adding this check until server
-    # has been updated
+    web_app.settings['bookstore'] = {
+        "version": version,
+        "validation": validate_bookstore(bookstore_settings), 
+        }
 
     check_published = [
-        web_app.settings['bookstore_validation'].get("bookstore_valid"),
-        web_app.settings['bookstore_validation'].get("publish_valid"),
+        web_app.settings['bookstore']['validation'].get("bookstore_valid"),
+        web_app.settings['bookstore']['validation'].get("publish_valid"),
     ]
 
     if not all(check_published):

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -21,14 +21,7 @@ class BookstoreVersionHandler(APIHandler):
 
     @web.authenticated
     def get(self):
-        self.finish(
-            json.dumps(
-                {
-                    "bookstore": True,
-                    **self.settings['bookstore']
-                }
-            )
-        )
+        self.finish(json.dumps({"bookstore": True, **self.settings['bookstore']}))
 
 
 # NOTE: We need to ensure that publishing is not configured if bookstore settings are not
@@ -111,8 +104,8 @@ def load_jupyter_server_extension(nb_app):
     bookstore_settings = BookstoreSettings(parent=nb_app)
     web_app.settings['bookstore'] = {
         "version": version,
-        "validation": validate_bookstore(bookstore_settings), 
-        }
+        "validation": validate_bookstore(bookstore_settings),
+    }
 
     check_published = [
         web_app.settings['bookstore']['validation'].get("bookstore_valid"),


### PR DESCRIPTION
This is a further iteration on how we will surface the settings via api and via the webapp settings for use by other serverextensions.