### PR TITLE
Address base_urls properly; handle path creation on the back end

### DIFF
--- a/bookstore/clone.html
+++ b/bookstore/clone.html
@@ -25,14 +25,13 @@ Distributed under the terms of the Modified BSD License.
             s3_bucket: "{{ s3_bucket }}",
             s3_key: "{{ s3_key }}"
           };
-          var clone_url = "{{ base_uri }}/api/bookstore/cloned/";
           var xsrf_token = getCookieByName("_xsrf");
           var xhr = new XMLHttpRequest();
           xhr.responseType = "json";
           xhr.onload = function(e) {
             if (xhr.readyState === 4) {
               if (xhr.status === 201) {
-                window.location.href = `{{ base_uri }}{{ default_url_base }}/${
+                window.location.href = `{{ redirect_contents_url }}/${
                   xhr.response.path
                 }`;
               } else {
@@ -44,7 +43,7 @@ Distributed under the terms of the Modified BSD License.
             console.error(xhr.statusText);
           };
 
-          xhr.open("POST", clone_url, true);
+          xhr.open("POST", "{{ clone_api_url }}", true);
           xhr.withCredentials = true;
           xhr.setRequestHeader("X-XSRFToken", xsrf_token);
           xhr.setRequestHeader(

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -3,6 +3,7 @@ import os
 
 import aiobotocore
 
+from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler
 from tornado import web
 from jinja2 import FileSystemLoader
@@ -69,11 +70,13 @@ class BookstoreCloneHandler(IPythonHandler):
             raise web.HTTPError(400, "Must have a key to clone from")
         self.set_header('Content-Type', 'text/html')
         base_uri = f"{self.request.protocol}://{self.request.host}"
+        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")
+        redirect_contents_url = url_path_join(base_uri, self.default_url)
         template_params = {
             "s3_bucket": s3_bucket,
             "s3_key": file_key,
-            "base_uri": base_uri,
-            "default_url_base": self.default_url,
+            "clone_api_url": clone_api_url,
+            "redirect_contents_url": redirect_contents_url,
         }
 
         self.write(self.render_template('clone.html', **template_params))

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -3,7 +3,6 @@ import os
 
 import aiobotocore
 
-from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler
 from tornado import web
 from jinja2 import FileSystemLoader
@@ -11,7 +10,7 @@ from jinja2 import FileSystemLoader
 from . import PACKAGE_DIR
 from .s3_paths import s3_path
 from .bookstore_config import BookstoreSettings
-
+from .utils import url_path_join
 
 BOOKSTORE_FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -3,7 +3,7 @@ import json
 
 from notebook.base.handlers import APIHandler
 from notebook.base.handlers import path_regex
-from notebook.utils import url_path_join
+from .utils import url_path_join
 from tornado import web
 
 from ._version import __version__

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -4,13 +4,13 @@ import aiobotocore
 
 from notebook.base.handlers import APIHandler
 from notebook.base.handlers import path_regex
-from notebook.utils import url_path_join
 from tornado import web
 
 from .s3_paths import s3_path
 from .s3_paths import s3_key
 from .s3_paths import s3_display_path
 from .bookstore_config import BookstoreSettings
+from .utils import url_path_join
 
 
 class BookstorePublishHandler(APIHandler):

--- a/bookstore/utils.py
+++ b/bookstore/utils.py
@@ -1,0 +1,1 @@
+from notebook.utils import url_path_join

--- a/bookstore/utils.py
+++ b/bookstore/utils.py
@@ -1,1 +1,16 @@
-from notebook.utils import url_path_join
+def url_path_join(*pieces):
+    """Join components of url into a relative url
+    Use to prevent double slash when joining subpath. This will leave the
+    initial and final / in place
+    """
+    initial = pieces[0].startswith('/')
+    final = pieces[-1].endswith('/')
+    stripped = [s.strip('/') for s in pieces]
+    result = '/'.join(s for s in stripped if s)
+    if initial:
+        result = '/' + result
+    if final:
+        result = result + '/'
+    if result == '//':
+        result = '/'
+    return result

--- a/bookstore/utils.py
+++ b/bookstore/utils.py
@@ -1,7 +1,13 @@
+"""Utility and helper functions."""
+
+
 def url_path_join(*pieces):
-    """Join components of url into a relative url
+    """Join components into a relative url.
+    
     Use to prevent double slash when joining subpath. This will leave the
-    initial and final / in place
+    initial and final / in place.
+    
+    Code based on Jupyter notebook `url_path_join`.
     """
     initial = pieces[0].startswith('/')
     final = pieces[-1].endswith('/')


### PR DESCRIPTION
Currently, the clone landing page from the GET api does not properly resolve base_urls. This addresses it. 

As it relates to https://github.com/nteract/bookstore/pull/75#discussion_r280785802 and the todo in https://github.com/nteract/bookstore/pull/88:
This is a case where because we lac a `url_path_join` utility in the front-end, it is easier to rely on the one provided by the notebook package from the backend rather than doing the text parsing for ourselves.

For example, working with `base_url`s causes a lot of headaches.

```
ipdb> self.default_url
'/blah/tree'
ipdb> self.base_url
'/blah/'
```

@willingc given your experience from JupyterHub & it's routing & base_url paradigms is there a better way to get access to the host name & protocol than to pull it from the request?