### PR TITLE
Clone GET Testing

### DIFF
--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -71,18 +71,22 @@ class BookstoreCloneHandler(IPythonHandler):
 
         self.log.info("Setting up cloning landing page from %s", s3_object_key)
 
+        template_params = self.construct_template_params(s3_bucket, s3_object_key)
         self.set_header('Content-Type', 'text/html')
+        self.write(self.render_template('clone.html', **template_params))
+
+    def construct_template_params(self, s3_bucket, s3_object_key):
         base_uri = f"{self.request.protocol}://{self.request.host}"
         clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")
         redirect_contents_url = url_path_join(base_uri, self.default_url)
         template_params = {
             "s3_bucket": s3_bucket,
-            "s3_key": file_key,
+            "s3_key": s3_object_key,
             "clone_api_url": clone_api_url,
             "redirect_contents_url": redirect_contents_url,
         }
+        return template_params
 
-        self.write(self.render_template('clone.html', **template_params))
 
     @web.authenticated
     async def post(self):

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -60,13 +60,17 @@ class BookstoreCloneHandler(IPythonHandler):
     async def get(self):
         """Open a page that will allow you to clone a notebook from a specific bucket.
         """
-        s3_bucket = self.get_argument("s3_bucket", "")
-        # s3_paths module has an s3_key function; file_key avoids confusion
-        file_key = self.get_argument("s3_key", "")
-        self.log.info("About to clone from %s", file_key)
+        s3_bucket = self.get_argument("s3_bucket")
+        if s3_bucket == '' or s3_bucket == "/":
+            raise web.HTTPError(400, "Must have a bucket to clone from")
 
-        if file_key == '' or file_key == '/':
+        # s3_paths module has an s3_key function; s3_object_key avoids confusion
+        s3_object_key = self.get_argument("s3_key")
+        if s3_object_key == '' or s3_object_key == '/':
             raise web.HTTPError(400, "Must have a key to clone from")
+
+        self.log.info("Setting up cloning landing page from %s", s3_object_key)
+
         self.set_header('Content-Type', 'text/html')
         base_uri = f"{self.request.protocol}://{self.request.host}"
         clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -1,0 +1,22 @@
+from unittest.mock import Mock
+
+import pytest
+from tornado.testing import AsyncTestCase, gen_test
+from tornado.web import Application, HTTPError
+from tornado.httpserver import HTTPRequest
+
+from ..clone import BookstoreCloneHandler
+
+def handler(uri='/api/bookstore/cloned'):
+    mock_application = Mock(spec=Application, ui_methods={}, ui_modules={}, settings={})
+    payload_request = HTTPRequest(method='GET', uri=uri, headers=None, body=None, connection=Mock())
+
+    handler = BookstoreCloneHandler(mock_application, payload_request)
+    return handler
+
+
+class TestSomeHandler(AsyncTestCase):
+    @gen_test
+    def test_no_param(self):
+        with pytest.raises(HTTPError):
+            yield handler().get()

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -36,3 +36,19 @@ class TestCloneHandler(AsyncTestCase):
         with pytest.raises(HTTPError):
             await empty_handler.get()
 
+    @gen_test
+    async def test_get_no_bucket(self):
+        no_bucket_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=&s3_key=hi')
+        with pytest.raises(HTTPError):
+            await no_bucket_handler.get()
+
+    @gen_test
+    async def test_get_no_object_key(self):
+        no_object_key_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=')
+        with pytest.raises(HTTPError):
+            await no_object_key_handler.get()
+
+    @gen_test
+    async def test_get_success(self):
+        success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
+        await success_handler.get()

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -25,8 +25,13 @@ class TestCloneHandler(AsyncTestCase):
         )
 
     def get_handler(self, uri):
+        connection = Mock(context=Mock(protocol="https"))
         payload_request = HTTPRequest(
-            method='GET', uri=uri, headers=None, body=None, connection=Mock()
+            method='GET',
+            uri=uri,
+            headers={"Host": "localhost:8888"},
+            body=None,
+            connection=connection,
         )
         return BookstoreCloneHandler(self.mock_application, payload_request)
 
@@ -52,3 +57,18 @@ class TestCloneHandler(AsyncTestCase):
     async def test_get_success(self):
         success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
         await success_handler.get()
+
+    def test_gen_template_params(self):
+        success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
+        expected = {
+            's3_bucket': 'hello',
+            's3_key': 'my_key',
+            'clone_api_url': 'https://localhost:8888/api/bookstore/cloned',
+            'redirect_contents_url': 'https://localhost:8888',
+        }
+        success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
+        output = success_handler.construct_template_params(
+            s3_bucket="hello", s3_object_key="my_key"
+        )
+        assert expected == output
+

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -10,14 +10,6 @@ from jinja2 import Environment
 from ..clone import BookstoreCloneHandler
 
 
-def handler(uri='/api/bookstore/cloned'):
-    mock_application = Mock(spec=Application, ui_methods={}, ui_modules={}, settings={})
-    payload_request = HTTPRequest(method='GET', uri=uri, headers=None, body=None, connection=Mock())
-
-    handler = BookstoreCloneHandler(mock_application, payload_request)
-    return handler
-
-
 class TestCloneHandler(AsyncTestCase):
     def setUp(self):
         super().setUp()

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -5,6 +5,8 @@ from tornado.testing import AsyncTestCase, gen_test
 from tornado.web import Application, HTTPError
 from tornado.httpserver import HTTPRequest
 
+from jinja2 import Environment
+
 from ..clone import BookstoreCloneHandler
 
 def handler(uri='/api/bookstore/cloned'):
@@ -15,8 +17,22 @@ def handler(uri='/api/bookstore/cloned'):
     return handler
 
 
-class TestSomeHandler(AsyncTestCase):
+class TestCloneHandler(AsyncTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_application = Mock(
+            spec=Application, ui_methods={}, ui_modules={}, settings={'jinja2_env': Environment()}
+        )
+
+    def get_handler(self, uri):
+        payload_request = HTTPRequest(
+            method='GET', uri=uri, headers=None, body=None, connection=Mock()
+        )
+        return BookstoreCloneHandler(self.mock_application, payload_request)
+
     @gen_test
-    def test_no_param(self):
+    async def test_get_no_param(self):
+        empty_handler = self.get_handler('/api/bookstore/cloned')
         with pytest.raises(HTTPError):
-            yield handler().get()
+            await empty_handler.get()
+


### PR DESCRIPTION
This adds testing functionality and mocking for the clone handler's GET methods. 

This mostly was focused on figuring out how to mock up most of what we need to test the handler without actually requiring a running server. 

This also factors out the parameterization for the template so that we can test that separately. 

To get the POST tested will require adding moto (to mock up s3 and interactions with `aiobotocore`).

Many thanks to @mseal for help getting the initial framework up and running.