### PR TITLE
Add POST handler tests for cloning

### DIFF
--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -10,7 +10,7 @@ from tornado.web import Application, HTTPError
 from tornado.httpserver import HTTPRequest
 
 
-from ..clone import BookstoreCloneHandler
+from ..clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
 
 
 class TestCloneHandler(AsyncTestCase):
@@ -30,15 +30,6 @@ class TestCloneHandler(AsyncTestCase):
             headers={"Host": "localhost:8888"},
             body=None,
             connection=connection,
-        )
-        return BookstoreCloneHandler(app, payload_request)
-
-    def post_handler(self, body_dict, app=None):
-        if app is None:
-            app = self.mock_application
-        body = json.dumps(body_dict).encode('utf-8')
-        payload_request = HTTPRequest(
-            method='POST', uri="/api/bookstore/cloned", headers=None, body=body, connection=Mock()
         )
         return BookstoreCloneHandler(app, payload_request)
 
@@ -103,6 +94,23 @@ class TestCloneHandler(AsyncTestCase):
             )
             assert expected == output
 
+
+class TestCloneAPIHandler(AsyncTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_application = Mock(
+            spec=Application, ui_methods={}, ui_modules={}, settings={'jinja2_env': Environment()}
+        )
+
+    def post_handler(self, body_dict, app=None):
+        if app is None:
+            app = self.mock_application
+        body = json.dumps(body_dict).encode('utf-8')
+        payload_request = HTTPRequest(
+            method='POST', uri="/api/bookstore/cloned", headers=None, body=body, connection=Mock()
+        )
+        return BookstoreCloneAPIHandler(app, payload_request)
+
     @gen_test
     async def test_post_no_body(self):
         post_body_dict = {}
@@ -123,4 +131,3 @@ class TestCloneHandler(AsyncTestCase):
         empty_key_handler = self.post_handler(post_body_dict)
         with pytest.raises(HTTPError):
             await empty_key_handler.post()
-

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -150,3 +150,12 @@ class TestCloneAPIHandler(AsyncTestCase):
         success_handler = self.post_handler(post_body_dict)
         with pytest.raises(HTTPError):
             await success_handler.post()
+
+    @gen_test
+    async def test_private_clone_nonsense_params(self):
+        s3_bucket = "my_key"
+        s3_object_key = "my_bucket"
+        post_body_dict = {"s3_key": s3_object_key, "s3_bucket": s3_bucket}
+        success_handler = self.post_handler(post_body_dict)
+        with pytest.raises(HTTPError):
+            await success_handler._clone(s3_bucket, s3_object_key)

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -8,6 +8,7 @@ from jinja2 import Environment
 from tornado.testing import AsyncTestCase, gen_test
 from tornado.web import Application, HTTPError
 from tornado.httpserver import HTTPRequest
+from traitlets.config import Config
 
 
 from ..clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
@@ -98,8 +99,19 @@ class TestCloneHandler(AsyncTestCase):
 class TestCloneAPIHandler(AsyncTestCase):
     def setUp(self):
         super().setUp()
+        mock_settings = {
+            "BookstoreSettings": {
+                "s3_access_key_id": "mock_id",
+                "s3_secret_access_key": "mock_access",
+            }
+        }
+        config = Config(mock_settings)
+
         self.mock_application = Mock(
-            spec=Application, ui_methods={}, ui_modules={}, settings={'jinja2_env': Environment()}
+            spec=Application,
+            ui_methods={},
+            ui_modules={},
+            settings={'jinja2_env': Environment(), "config": config},
         )
 
     def post_handler(self, body_dict, app=None):

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -143,3 +143,10 @@ class TestCloneAPIHandler(AsyncTestCase):
         empty_key_handler = self.post_handler(post_body_dict)
         with pytest.raises(HTTPError):
             await empty_key_handler.post()
+
+    @gen_test
+    async def test_post_nonsense_params(self):
+        post_body_dict = {"s3_key": "my_key", "s3_bucket": "my_bucket"}
+        success_handler = self.post_handler(post_body_dict)
+        with pytest.raises(HTTPError):
+            await success_handler.post()


### PR DESCRIPTION
This continues #102 to add more testing for the post handler.

I have not yet gotten the mock to work correctly to test the newly introduced helper function.

This also adds a quick fix to the js files that had broken the CI tests when run locally. It's concerning to me that that didn't come up in our CI testing, since updating a const should always cause an issue which suggests the tests weren't being run