### PR TITLE
Refactor Clone handler

### DIFF
--- a/bookstore/client/__init__.py
+++ b/bookstore/client/__init__.py
@@ -1,1 +1,1 @@
-from .bookstore import BookstoreClient
+from .store_client import BookstoreClient

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -18,9 +18,8 @@ BOOKSTORE_FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 class BookstoreCloneHandler(IPythonHandler):
     """Handle notebook clone from storage.
 
-    Provides API handling for ``GET`` and ``POST`` when cloning a notebook
-    from storage (S3). Launches a user interface cloning options page when
-    ``GET`` is sent.
+    Provides handling for ``GET`` requests when cloning a notebook
+    from storage (S3). Launches a user interface with cloning options.
 
     Methods
     -------
@@ -30,8 +29,6 @@ class BookstoreCloneHandler(IPythonHandler):
         Checks for valid storage settings and render a UI for clone options.
     construct_template_params(self, s3_bucket, s3_object_key)
         Helper to populate Jinja template for cloning option page.
-    post(self)
-        Clone a notebook from the location specified by the payload.
     get_template(self, name)
         Loads a Jinja template and its related settings.
 
@@ -46,10 +43,10 @@ class BookstoreCloneHandler(IPythonHandler):
 
     @web.authenticated
     async def get(self):
-        """GET /api/bookstore/cloned
+        """GET /bookstore/clone?s3_bucket=<your_s3_bucket>&s3_key=<your_s3_key>
 
         Renders an options page that will allow you to clone a notebook
-        from a specific bucket.
+        from a specific bucket via the Bookstore cloning API.
         """
         s3_bucket = self.get_argument("s3_bucket")
         if s3_bucket == '' or s3_bucket == "/":
@@ -87,22 +84,15 @@ class BookstoreCloneHandler(IPythonHandler):
 class BookstoreCloneAPIHandler(APIHandler):
     """Handle notebook clone from storage.
 
-    Provides API handling for ``GET`` and ``POST`` when cloning a notebook
-    from storage (S3). Launches a user interface cloning options page when
-    ``GET`` is sent.
+    Provides API handling for ``POST`` when cloning a notebook
+    from storage (S3).
 
     Methods
     -------
     initialize(self)
         Helper to access bookstore settings.
-    get(self)
-        Checks for valid storage settings and render a UI for clone options.
-    construct_template_params(self, s3_bucket, s3_object_key)
-        Helper to populate Jinja template for cloning option page.
     post(self)
         Clone a notebook from the location specified by the payload.
-    get_template(self, name)
-        Loads a Jinja template and its related settings.
 
     See also
     --------

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -4,7 +4,7 @@ import os
 
 import aiobotocore
 from jinja2 import FileSystemLoader
-from notebook.base.handlers import IPythonHandler
+from notebook.base.handlers import IPythonHandler, APIHandler
 from tornado import web
 
 from . import PACKAGE_DIR
@@ -16,6 +16,144 @@ BOOKSTORE_FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 
 
 class BookstoreCloneHandler(IPythonHandler):
+    """Handle notebook clone from storage.
+
+    Provides API handling for ``GET`` and ``POST`` when cloning a notebook
+    from storage (S3). Launches a user interface cloning options page when
+    ``GET`` is sent.
+
+    Methods
+    -------
+    initialize(self)
+        Helper to access bookstore settings.
+    get(self)
+        Checks for valid storage settings and render a UI for clone options.
+    construct_template_params(self, s3_bucket, s3_object_key)
+        Helper to populate Jinja template for cloning option page.
+    post(self)
+        Clone a notebook from the location specified by the payload.
+    get_template(self, name)
+        Loads a Jinja template and its related settings.
+
+    See also
+    --------
+    `Jupyter Notebook reference on Custom Handlers <https://jupyter-notebook.readthedocs.io/en/stable/extending/handlers.html#registering-custom-handlers>`_
+    """
+
+    def initialize(self):
+        """Helper to retrieve bookstore setting for the session."""
+        self.bookstore_settings = BookstoreSettings(config=self.config)
+
+        self.session = aiobotocore.get_session()
+
+    async def _clone(self, s3_bucket, file_key):
+        path = file_key
+
+        self.log.info(f"bucket: {s3_bucket}")
+        self.log.info(f"key: {file_key}")
+        full_s3_path = s3_path(s3_bucket, path)
+
+        async with self.session.create_client(
+            's3',
+            aws_secret_access_key=self.bookstore_settings.s3_secret_access_key,
+            aws_access_key_id=self.bookstore_settings.s3_access_key_id,
+            endpoint_url=self.bookstore_settings.s3_endpoint_url,
+            region_name=self.bookstore_settings.s3_region_name,
+        ) as client:
+            self.log.info("Processing published write of %s", path)
+            obj = await client.get_object(Bucket=s3_bucket, Key=file_key)
+            content = await obj['Body'].read()
+            self.log.info("Done with published write of %s", path)
+
+        resp_content = {"s3_path": full_s3_path}
+        model = {
+            "type": "file",
+            "format": "text",
+            "mimetype": "text/plain",
+            "content": content.decode('utf-8'),
+        }
+        self.set_status(201)
+
+        if 'VersionId' in obj:
+            resp_content["versionID"] = obj['VersionId']
+        return model
+
+    @web.authenticated
+    async def get(self):
+        """GET /api/bookstore/cloned
+
+        Renders an options page that will allow you to clone a notebook
+        from a specific bucket.
+        """
+        s3_bucket = self.get_argument("s3_bucket")
+        if s3_bucket == '' or s3_bucket == "/":
+            raise web.HTTPError(400, "Must have a bucket to clone from")
+
+        # s3_paths module has an s3_key function; s3_object_key avoids confusion
+        s3_object_key = self.get_argument("s3_key")
+        if s3_object_key == '' or s3_object_key == '/':
+            raise web.HTTPError(400, "Must have a key to clone from")
+
+        self.log.info("Setting up cloning landing page from %s", s3_object_key)
+
+        template_params = self.construct_template_params(s3_bucket, s3_object_key)
+        self.set_header('Content-Type', 'text/html')
+        self.write(self.render_template('clone.html', **template_params))
+
+    def construct_template_params(self, s3_bucket, s3_object_key):
+        """Helper that takes valid S3 parameters and populates UI template"""
+        base_uri = f"{self.request.protocol}://{self.request.host}"
+        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")
+        redirect_contents_url = url_path_join(base_uri, self.default_url)
+        template_params = {
+            "s3_bucket": s3_bucket,
+            "s3_key": s3_object_key,
+            "clone_api_url": clone_api_url,
+            "redirect_contents_url": redirect_contents_url,
+        }
+        return template_params
+
+    @web.authenticated
+    async def post(self):
+        """POST /api/bookstore/cloned
+
+        Clone a notebook to the path specified in the payload.
+
+        The payload type for the request should be::
+
+            {
+            "s3_bucket": string,
+            "s3_key": string,
+            "target_path"?: string
+            }
+
+        The response payload should match the standard Jupyter contents
+        API POST response.
+        """
+        model = self.get_json_body()
+        s3_bucket = model.get("s3_bucket", "")
+        # s3_paths module has an s3_key function; file_key avoids confusion
+        file_key = model.get("s3_key", "")
+        target_path = model.get("target_path", "") or os.path.basename(os.path.relpath(file_key))
+
+        self.log.info("About to clone from %s", file_key)
+
+        if file_key == '' or file_key == '/':
+            raise web.HTTPError(400, "Must have an S3 key to perform clone.")
+        model = await self._clone(s3_bucket, file_key)
+        self.set_header('Content-Type', 'application/json')
+        path = self.contents_manager.increment_filename(target_path)
+        model['name'] = os.path.basename(os.path.relpath(path))
+        model['path'] = os.path.relpath(path)
+        self.contents_manager.save(model, path)
+        self.finish(model)
+
+    def get_template(self, name):
+        """Loads a Jinja template by name."""
+        return BOOKSTORE_FILE_LOADER.load(self.settings['jinja2_env'], name)
+
+
+class BookstoreCloneAPIHandler(APIHandler):
     """Handle notebook clone from storage.
 
     Provides API handling for ``GET`` and ``POST`` when cloning a notebook

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -16,7 +16,7 @@ BOOKSTORE_FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 
 
 class BookstoreCloneHandler(IPythonHandler):
-    """Handle notebook clone from storage.
+    """Prepares and provides clone options page, populating UI with clone option parameters.
 
     Provides handling for ``GET`` requests when cloning a notebook
     from storage (S3). Launches a user interface with cloning options.
@@ -47,15 +47,18 @@ class BookstoreCloneHandler(IPythonHandler):
 
         Renders an options page that will allow you to clone a notebook
         from a specific bucket via the Bookstore cloning API.
+
+        s3_bucket is the bucket you wish to clone from.
+        s3_key is the object key that you wish to clone.
         """
         s3_bucket = self.get_argument("s3_bucket")
         if s3_bucket == '' or s3_bucket == "/":
-            raise web.HTTPError(400, "Must have a bucket to clone from")
+            raise web.HTTPError(400, "Requires an S3 bucket in order to clone")
 
         # s3_paths module has an s3_key function; s3_object_key avoids confusion
         s3_object_key = self.get_argument("s3_key")
         if s3_object_key == '' or s3_object_key == '/':
-            raise web.HTTPError(400, "Must have a key to clone from")
+            raise web.HTTPError(400, "Requires an S3 object key in order to clone")
 
         self.log.info("Setting up cloning landing page from %s", s3_object_key)
 
@@ -73,7 +76,7 @@ class BookstoreCloneHandler(IPythonHandler):
             Template parameters in a dictionary
         """
         base_uri = f"{self.request.protocol}://{self.request.host}"
-        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")
+        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/clone")
         redirect_contents_url = url_path_join(base_uri, self.default_url)
         template_params = {
             "s3_bucket": s3_bucket,

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -139,7 +139,7 @@ class BookstoreCloneAPIHandler(APIHandler):
 
     @web.authenticated
     async def post(self):
-        """POST /api/bookstore/cloned
+        """POST /api/bookstore/clone
 
         Clone a notebook to the path specified in the payload.
 

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -84,7 +84,7 @@ class BookstoreCloneHandler(IPythonHandler):
 class BookstoreCloneAPIHandler(APIHandler):
     """Handle notebook clone from storage.
 
-    Provides API handling for ``POST`` when cloning a notebook
+    Provides API handling for ``POST`` and clones a notebook
     from storage (S3).
 
     Methods

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -64,7 +64,14 @@ class BookstoreCloneHandler(IPythonHandler):
         self.write(self.render_template('clone.html', **template_params))
 
     def construct_template_params(self, s3_bucket, s3_object_key):
-        """Helper that takes valid S3 parameters and populates UI template"""
+        """Helper that takes valid S3 parameters and populates UI template
+        
+        Returns
+        --------
+        
+        dict
+            Template parameters in a dictionary
+        """
         base_uri = f"{self.request.protocol}://{self.request.host}"
         clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")
         redirect_contents_url = url_path_join(base_uri, self.default_url)

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -44,40 +44,6 @@ class BookstoreCloneHandler(IPythonHandler):
         """Helper to retrieve bookstore setting for the session."""
         self.bookstore_settings = BookstoreSettings(config=self.config)
 
-        self.session = aiobotocore.get_session()
-
-    async def _clone(self, s3_bucket, file_key):
-        path = file_key
-
-        self.log.info(f"bucket: {s3_bucket}")
-        self.log.info(f"key: {file_key}")
-        full_s3_path = s3_path(s3_bucket, path)
-
-        async with self.session.create_client(
-            's3',
-            aws_secret_access_key=self.bookstore_settings.s3_secret_access_key,
-            aws_access_key_id=self.bookstore_settings.s3_access_key_id,
-            endpoint_url=self.bookstore_settings.s3_endpoint_url,
-            region_name=self.bookstore_settings.s3_region_name,
-        ) as client:
-            self.log.info("Processing published write of %s", path)
-            obj = await client.get_object(Bucket=s3_bucket, Key=file_key)
-            content = await obj['Body'].read()
-            self.log.info("Done with published write of %s", path)
-
-        resp_content = {"s3_path": full_s3_path}
-        model = {
-            "type": "file",
-            "format": "text",
-            "mimetype": "text/plain",
-            "content": content.decode('utf-8'),
-        }
-        self.set_status(201)
-
-        if 'VersionId' in obj:
-            resp_content["versionID"] = obj['VersionId']
-        return model
-
     @web.authenticated
     async def get(self):
         """GET /api/bookstore/cloned
@@ -112,41 +78,6 @@ class BookstoreCloneHandler(IPythonHandler):
             "redirect_contents_url": redirect_contents_url,
         }
         return template_params
-
-    @web.authenticated
-    async def post(self):
-        """POST /api/bookstore/cloned
-
-        Clone a notebook to the path specified in the payload.
-
-        The payload type for the request should be::
-
-            {
-            "s3_bucket": string,
-            "s3_key": string,
-            "target_path"?: string
-            }
-
-        The response payload should match the standard Jupyter contents
-        API POST response.
-        """
-        model = self.get_json_body()
-        s3_bucket = model.get("s3_bucket", "")
-        # s3_paths module has an s3_key function; file_key avoids confusion
-        file_key = model.get("s3_key", "")
-        target_path = model.get("target_path", "") or os.path.basename(os.path.relpath(file_key))
-
-        self.log.info("About to clone from %s", file_key)
-
-        if file_key == '' or file_key == '/':
-            raise web.HTTPError(400, "Must have an S3 key to perform clone.")
-        model = await self._clone(s3_bucket, file_key)
-        self.set_header('Content-Type', 'application/json')
-        path = self.contents_manager.increment_filename(target_path)
-        model['name'] = os.path.basename(os.path.relpath(path))
-        model['path'] = os.path.relpath(path)
-        self.contents_manager.save(model, path)
-        self.finish(model)
 
     def get_template(self, name):
         """Loads a Jinja template by name."""

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -148,41 +148,6 @@ class BookstoreCloneAPIHandler(APIHandler):
         return model
 
     @web.authenticated
-    async def get(self):
-        """GET /api/bookstore/cloned
-
-        Renders an options page that will allow you to clone a notebook
-        from a specific bucket.
-        """
-        s3_bucket = self.get_argument("s3_bucket")
-        if s3_bucket == '' or s3_bucket == "/":
-            raise web.HTTPError(400, "Must have a bucket to clone from")
-
-        # s3_paths module has an s3_key function; s3_object_key avoids confusion
-        s3_object_key = self.get_argument("s3_key")
-        if s3_object_key == '' or s3_object_key == '/':
-            raise web.HTTPError(400, "Must have a key to clone from")
-
-        self.log.info("Setting up cloning landing page from %s", s3_object_key)
-
-        template_params = self.construct_template_params(s3_bucket, s3_object_key)
-        self.set_header('Content-Type', 'text/html')
-        self.write(self.render_template('clone.html', **template_params))
-
-    def construct_template_params(self, s3_bucket, s3_object_key):
-        """Helper that takes valid S3 parameters and populates UI template"""
-        base_uri = f"{self.request.protocol}://{self.request.host}"
-        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/cloned")
-        redirect_contents_url = url_path_join(base_uri, self.default_url)
-        template_params = {
-            "s3_bucket": s3_bucket,
-            "s3_key": s3_object_key,
-            "clone_api_url": clone_api_url,
-            "redirect_contents_url": redirect_contents_url,
-        }
-        return template_params
-
-    @web.authenticated
     async def post(self):
         """POST /api/bookstore/cloned
 
@@ -216,7 +181,3 @@ class BookstoreCloneAPIHandler(APIHandler):
         model['path'] = os.path.relpath(path)
         self.contents_manager.save(model, path)
         self.finish(model)
-
-    def get_template(self, name):
-        """Loads a Jinja template by name."""
-        return BOOKSTORE_FILE_LOADER.load(self.settings['jinja2_env'], name)

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -10,7 +10,7 @@ from ._version import __version__
 from .bookstore_config import BookstoreSettings
 from .bookstore_config import validate_bookstore
 from .publish import BookstorePublishHandler
-from .clone import BookstoreCloneHandler
+from .clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
 
 
 version = __version__
@@ -45,8 +45,9 @@ def load_jupyter_server_extension(nb_app):
     host_pattern = '.*$'
 
     # Always enable the version handler
-    base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
-    web_app.add_handlers(host_pattern, [(base_bookstore_pattern, BookstoreVersionHandler)])
+    base_bookstore_pattern = url_path_join(web_app.settings['base_url'], '/bookstore')
+    base_bookstore_api_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
+    web_app.add_handlers(host_pattern, [(base_bookstore_api_pattern, BookstoreVersionHandler)])
     bookstore_settings = BookstoreSettings(parent=nb_app)
     web_app.settings['bookstore'] = {
         "version": version,
@@ -66,7 +67,7 @@ def load_jupyter_server_extension(nb_app):
             host_pattern,
             [
                 (
-                    url_path_join(base_bookstore_pattern, r"/published%s" % path_regex),
+                    url_path_join(base_bookstore_api_pattern, r"/published%s" % path_regex),
                     BookstorePublishHandler,
                 )
             ],
@@ -74,5 +75,11 @@ def load_jupyter_server_extension(nb_app):
 
     web_app.add_handlers(
         host_pattern,
-        [(url_path_join(base_bookstore_pattern, r"/cloned(?:/?)*"), BookstoreCloneHandler)],
+        [
+            (
+                url_path_join(base_bookstore_api_pattern, r"/cloned(?:/?)*"),
+                BookstoreCloneAPIHandler,
+            ),
+            (url_path_join(base_bookstore_pattern, r"/clone(?:/?)*"), BookstoreCloneHandler),
+        ],
     )

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -67,7 +67,7 @@ def load_jupyter_server_extension(nb_app):
             host_pattern,
             [
                 (
-                    url_path_join(base_bookstore_api_pattern, r"/published%s" % path_regex),
+                    url_path_join(base_bookstore_api_pattern, r"/publish%s" % path_regex),
                     BookstorePublishHandler,
                 )
             ],
@@ -76,10 +76,7 @@ def load_jupyter_server_extension(nb_app):
     web_app.add_handlers(
         host_pattern,
         [
-            (
-                url_path_join(base_bookstore_api_pattern, r"/cloned(?:/?)*"),
-                BookstoreCloneAPIHandler,
-            ),
+            (url_path_join(base_bookstore_api_pattern, r"/clone(?:/?)*"), BookstoreCloneAPIHandler),
             (url_path_join(base_bookstore_pattern, r"/clone(?:/?)*"), BookstoreCloneHandler),
         ],
     )

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -23,6 +23,8 @@ class BookstorePublishHandler(APIHandler):
     async def put(self, path):
         """Publish a notebook on a given path.
 
+        PUT /api/bookstore/publish
+
         The payload directly matches the contents API for PUT.
         """
         self.log.info("Attempt publishing to %s", path)

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -58,7 +58,7 @@ class TestCloneHandler(AsyncTestCase):
         expected = {
             's3_bucket': 'hello',
             's3_key': 'my_key',
-            'clone_api_url': 'https://localhost:8888/bookstore/clone',
+            'clone_api_url': 'https://localhost:8888/api/bookstore/clone',
             'redirect_contents_url': 'https://localhost:8888',
         }
         success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
@@ -72,7 +72,7 @@ class TestCloneHandler(AsyncTestCase):
         expected = {
             's3_bucket': 'hello',
             's3_key': 'my_key',
-            'clone_api_url': 'https://localhost:8888/my_base_url/bookstore/clone',
+            'clone_api_url': 'https://localhost:8888/my_base_url/api/bookstore/clone',
             'redirect_contents_url': 'https://localhost:8888',
         }
         for base_url in base_url_list:
@@ -84,7 +84,7 @@ class TestCloneHandler(AsyncTestCase):
             )
 
             success_handler = self.get_handler(
-                '/api/bookstore/clone?s3_bucket=hello&s3_key=my_key', app=mock_app
+                '/bookstore/clone?s3_bucket=hello&s3_key=my_key', app=mock_app
             )
             output = success_handler.construct_template_params(
                 s3_bucket="hello", s3_object_key="my_key"

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -32,36 +32,36 @@ class TestCloneHandler(AsyncTestCase):
 
     @gen_test
     async def test_get_no_param(self):
-        empty_handler = self.get_handler('/api/bookstore/cloned')
+        empty_handler = self.get_handler('/bookstore/clone')
         with pytest.raises(HTTPError):
             await empty_handler.get()
 
     @gen_test
     async def test_get_no_bucket(self):
-        no_bucket_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=&s3_key=hi')
+        no_bucket_handler = self.get_handler('/bookstore/clone?s3_bucket=&s3_key=hi')
         with pytest.raises(HTTPError):
             await no_bucket_handler.get()
 
     @gen_test
     async def test_get_no_object_key(self):
-        no_object_key_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=')
+        no_object_key_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=')
         with pytest.raises(HTTPError):
             await no_object_key_handler.get()
 
     @gen_test
     async def test_get_success(self):
-        success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
+        success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         await success_handler.get()
 
     def test_gen_template_params(self):
-        success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
+        success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         expected = {
             's3_bucket': 'hello',
             's3_key': 'my_key',
-            'clone_api_url': 'https://localhost:8888/api/bookstore/cloned',
+            'clone_api_url': 'https://localhost:8888/bookstore/clone',
             'redirect_contents_url': 'https://localhost:8888',
         }
-        success_handler = self.get_handler('/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key')
+        success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         output = success_handler.construct_template_params(
             s3_bucket="hello", s3_object_key="my_key"
         )
@@ -72,7 +72,7 @@ class TestCloneHandler(AsyncTestCase):
         expected = {
             's3_bucket': 'hello',
             's3_key': 'my_key',
-            'clone_api_url': 'https://localhost:8888/my_base_url/api/bookstore/cloned',
+            'clone_api_url': 'https://localhost:8888/my_base_url/bookstore/clone',
             'redirect_contents_url': 'https://localhost:8888',
         }
         for base_url in base_url_list:
@@ -84,7 +84,7 @@ class TestCloneHandler(AsyncTestCase):
             )
 
             success_handler = self.get_handler(
-                '/api/bookstore/cloned?s3_bucket=hello&s3_key=my_key', app=mock_app
+                '/api/bookstore/clone?s3_bucket=hello&s3_key=my_key', app=mock_app
             )
             output = success_handler.construct_template_params(
                 s3_bucket="hello", s3_object_key="my_key"

--- a/ci/integration.js
+++ b/ci/integration.js
@@ -231,7 +231,7 @@ const main = async () => {
     publishedPath,
     url_path_join(
       jupyterServer.endpoint,
-      `api/bookstore/cloned?s3_bucket=${bucketName}&s3_key=${publishedPath}`
+      `bookstore/clone?s3_bucket=${bucketName}&s3_key=${publishedPath}`
     )
   );
   const cloneRes = await jupyterServer.cloneNotebook(bucketName, publishedPath);

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -102,7 +102,7 @@ class JupyterServer {
   async publishNotebook(path, notebook) {
     // Once https://github.com/nteract/nteract/pull/3651 is merged, we can use
     // rx-jupyter for writing a notebook to the contents API
-    const apiPath = "/api/bookstore/published/";
+    const apiPath = "/api/bookstore/publish/";
     const xhr = await ajax({
       url: url_path_join(this.endpoint, apiPath, path),
       responseType: "json",

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -124,7 +124,7 @@ class JupyterServer {
   populateCloneQuery(s3Bucket, s3Key) {
     return url_path_join(
       this.endpoint,
-      `/api/bookstore/cloned?s3_bucket=${s3Bucket}&s3_key=${s3Key}`
+      `/bookstore/clone?s3_bucket=${s3Bucket}&s3_key=${s3Key}`
     );
   }
   async cloneNotebook(s3Bucket, s3Key) {

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -26,7 +26,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/VersionInfo'
-  /api/bookstore/cloned:
+  /bookstore/clone:
     get:
       tags:
       - clone
@@ -57,6 +57,7 @@ paths:
         400:
           description: Must have a key to clone from
           content: {}
+  /api/bookstore/cloned:
     post:
       tags:
       - clone

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -57,7 +57,7 @@ paths:
         400:
           description: Must have a key to clone from
           content: {}
-  /api/bookstore/cloned:
+  /api/bookstore/clone:
     post:
       tags:
       - clone
@@ -79,7 +79,7 @@ paths:
         400:
           description: Must have a key to clone from
           content: {}
-  /api/bookstore/published/{path}:
+  /api/bookstore/publish/{path}:
     put: 
       tags:
       - publish


### PR DESCRIPTION
Closes #109 

This does not address the switch in all of the APIs as well, I will add that to this PR as it seems thematically related enough to go with it (and it would run into merge conflicts with this if I were to make it an independent PR).

This introduces BookstoreCloneAPIHandler, that inherits from APIHandler rather than IPythonHandler.