### PR TITLE
Add test VersionHandler; Update Version Handler's API

### DIFF
--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -74,7 +74,7 @@ def validate_bookstore(settings: BookstoreSettings):
     Returns
     -------
     validation_checks : dict
-        Existence of settings by category (general, archive, publish)
+        Statements about whether features are validly configured and available
     """
     general_settings = [settings.s3_bucket != "", settings.s3_endpoint_url != ""]
     archive_settings = [*general_settings, settings.workspace_prefix != ""]
@@ -85,6 +85,6 @@ def validate_bookstore(settings: BookstoreSettings):
         "bookstore_valid": all(general_settings),
         "archive_valid": all(archive_settings),
         "publish_valid": all(published_settings),
-        "cloning_valid": all(cloning_settings),
+        "clone_valid": all(cloning_settings),
     }
     return validation_checks

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -41,13 +41,13 @@ class BookstoreVersionHandler(APIHandler):
         """Helper for building the version handler's response before serialization."""
         return {
             "release": self.settings['bookstore']["release"],
-            "validation": self.settings['bookstore']["validation"],
+            "features": self.settings['bookstore']["features"],
         }
 
 
 def build_settings_dict(validation):
     """Helper for building the settings info that will be assigned to the web_app."""
-    return {"release": version, "validation": validation}
+    return {"release": version, "features": validation}
 
 
 def load_jupyter_server_extension(nb_app):

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -34,8 +34,8 @@ class BookstoreVersionHandler(APIHandler):
         }
 
 
-def build_settings_dict(bookstore_settings):
-    return {"version": version, "validation": validate_bookstore(bookstore_settings)}
+def build_settings_dict(validation):
+    return {"version": version, "validation": validation}
 
 
 def load_jupyter_server_extension(nb_app):
@@ -46,7 +46,7 @@ def load_jupyter_server_extension(nb_app):
 
     bookstore_settings = BookstoreSettings(parent=nb_app)
     validation = validate_bookstore(bookstore_settings)
-    web_app.settings['bookstore'] = {"version": version, "validation": validation}
+    web_app.settings['bookstore'] = build_settings_dict(validation)
     handlers = collect_handlers(nb_app.log, base_url, validation)
     web_app.add_handlers(host_pattern, handlers)
 

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -40,15 +40,14 @@ class BookstoreVersionHandler(APIHandler):
     def build_response_dict(self):
         """Helper for building the version handler's response before serialization."""
         return {
-            "bookstore": True,  # TODO: Should we remove this; isn't it equivalent to the endpoint responding?
-            "version": self.settings['bookstore']["version"],
+            "release": self.settings['bookstore']["release"],
             "validation": self.settings['bookstore']["validation"],
         }
 
 
 def build_settings_dict(validation):
     """Helper for building the settings info that will be assigned to the web_app."""
-    return {"version": version, "validation": validation}
+    return {"release": version, "validation": validation}
 
 
 def load_jupyter_server_extension(nb_app):
@@ -103,7 +102,7 @@ def collect_handlers(log, base_url, validation):
     else:
         log.info("[bookstore] Publishing disabled. s3_bucket or endpoint are not configured.")
 
-    if validation['cloning_valid']:
+    if validation['clone_valid']:
         log.info(f"[bookstore] Enabling bookstore cloning, version: {version}")
         handlers.append(
             (url_path_join(base_bookstore_api_pattern, r"/clone(?:/?)*"), BookstoreCloneAPIHandler)

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -24,20 +24,14 @@ class BookstoreVersionHandler(APIHandler):
 
     @web.authenticated
     def get(self):
-        self.finish(
-            json.dumps(
-                {
-                    "bookstore": True,
-                    "version": self.settings['bookstore']["version"],
-                    "validation": self.settings['bookstore']["validation"],
-                }
-            )
-        )
+        self.finish(json.dumps(self.build_response_dict()))
 
-
-# TODO: Add a check. Note: We need to ensure that publishing is not configured if bookstore settings are not
-#       set. Because of how the APIHandlers cannot be configurable, all we can do is reach into settings
-#       For applications this will mean checking the config and then applying it in
+    def build_response_dict(self):
+        return {
+            "bookstore": True,
+            "version": self.settings['bookstore']["version"],
+            "validation": self.settings['bookstore']["validation"],
+        }
 
 
 def load_jupyter_server_extension(nb_app):

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -34,6 +34,10 @@ class BookstoreVersionHandler(APIHandler):
         }
 
 
+def build_settings_dict(bookstore_settings):
+    return {"version": version, "validation": validate_bookstore(bookstore_settings)}
+
+
 def load_jupyter_server_extension(nb_app):
     web_app = nb_app.web_app
     host_pattern = '.*$'

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -20,21 +20,34 @@ class BookstoreVersionHandler(APIHandler):
     """Handler responsible for Bookstore version information
 
     Used to lay foundations for the bookstore package. Though, frontends can use this endpoint for feature detection.
+
+    Methods
+    -------
+    get(self)
+        Provides version info and feature availability based on serverside settings.
+    build_response_dict(self)
+        Helper to populate response.
     """
 
     @web.authenticated
     def get(self):
+        """GET /api/bookstore/
+
+        Returns version info and validation info for various bookstore features.
+        """
         self.finish(json.dumps(self.build_response_dict()))
 
     def build_response_dict(self):
+        """Helper for building the version handler's response before serialization."""
         return {
-            "bookstore": True,
+            "bookstore": True,  # TODO: Should we remove this; isn't it equivalent to the endpoint responding?
             "version": self.settings['bookstore']["version"],
             "validation": self.settings['bookstore']["validation"],
         }
 
 
 def build_settings_dict(validation):
+    """Helper for building the settings info that will be assigned to the web_app."""
     return {"version": version, "validation": validation}
 
 

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -10,7 +10,7 @@ def test_validate_bookstore_defaults():
         "bookstore_valid": False,
         "publish_valid": False,
         "archive_valid": False,
-        "cloning_valid": True,
+        "clone_valid": True,
     }
     settings = BookstoreSettings()
     assert validate_bookstore(settings) == expected
@@ -22,7 +22,7 @@ def test_validate_bookstore_published():
         "bookstore_valid": True,
         "publish_valid": False,
         "archive_valid": True,
-        "cloning_valid": True,
+        "clone_valid": True,
     }
     settings = BookstoreSettings(s3_bucket="A_bucket", published_prefix="")
     assert validate_bookstore(settings) == expected
@@ -34,7 +34,7 @@ def test_validate_bookstore_workspace():
         "bookstore_valid": True,
         "publish_valid": True,
         "archive_valid": False,
-        "cloning_valid": True,
+        "clone_valid": True,
     }
     settings = BookstoreSettings(s3_bucket="A_bucket", workspace_prefix="")
     assert validate_bookstore(settings) == expected
@@ -46,7 +46,7 @@ def test_validate_bookstore_endpoint():
         "bookstore_valid": False,
         "publish_valid": False,
         "archive_valid": False,
-        "cloning_valid": True,
+        "clone_valid": True,
     }
     settings = BookstoreSettings(s3_endpoint_url="")
     assert validate_bookstore(settings) == expected
@@ -58,7 +58,7 @@ def test_validate_bookstore_bucket():
         "bookstore_valid": True,
         "publish_valid": True,
         "archive_valid": True,
-        "cloning_valid": True,
+        "clone_valid": True,
     }
     settings = BookstoreSettings(s3_bucket="A_bucket")
     assert validate_bookstore(settings) == expected
@@ -70,7 +70,7 @@ def test_disable_cloning():
         "bookstore_valid": True,
         "publish_valid": True,
         "archive_valid": True,
-        "cloning_valid": False,
+        "clone_valid": False,
     }
     settings = BookstoreSettings(s3_bucket="A_bucket", enable_cloning=False)
     assert validate_bookstore(settings) == expected

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 from unittest.mock import Mock
 
-from bookstore.handlers import collect_handlers, BookstoreVersionHandler
+from bookstore.handlers import collect_handlers, build_settings_dict, BookstoreVersionHandler
 from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 from bookstore.clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
 from bookstore.publish import BookstorePublishAPIHandler
@@ -60,7 +60,6 @@ def test_collect_handlers_no_publish():
     handlers = collect_handlers(log, '/', validation)
     assert expected == handlers
 
-
 def test_collect_handlers_only_version():
     expected = [('/api/bookstore', BookstoreVersionHandler)]
     web_app = Application()
@@ -69,3 +68,19 @@ def test_collect_handlers_only_version():
     validation = validate_bookstore(bookstore_settings)
     handlers = collect_handlers(log, '/', validation)
     assert expected == handlers
+
+@pytest.fixture
+def bookstore_settings():
+    mock_settings = {
+        "BookstoreSettings": {"s3_access_key_id": "mock_id", "s3_secret_access_key": "mock_access"}
+    }
+    config = Config(mock_settings)
+    return BookstoreSettings(config=config)
+
+
+def test_build_settings_dict(bookstore_settings):
+    expected = {
+        'validation': {'archive_valid': True, 'bookstore_valid': False, 'publish_valid': True},
+        'version': '2.3.0.dev',
+    }
+    assert expected == build_settings_dict(bookstore_settings)

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -5,6 +5,7 @@ import pytest
 import logging
 from unittest.mock import Mock
 
+from bookstore._version import __version__
 from bookstore.handlers import collect_handlers, build_settings_dict, BookstoreVersionHandler
 from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 from bookstore.clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
@@ -16,6 +17,7 @@ from tornado.httpserver import HTTPRequest
 from traitlets.config import Config
 
 log = logging.getLogger('test_handlers')
+version = __version__
 
 from traitlets.config import Config
 
@@ -90,13 +92,13 @@ def bookstore_settings(request):
 
 def test_build_settings_dict(bookstore_settings):
     expected = {
-        'version': '2.3.0.dev',
         'validation': {
             'archive_valid': True,
             'bookstore_valid': True,
             'publish_valid': True,
             'cloning_valid': True,
         },
+        'version': version,
     }
     validation = validate_bookstore(bookstore_settings)
     assert expected == build_settings_dict(validation)
@@ -152,12 +154,12 @@ class TestCloneAPIHandler(AsyncTestCase):
         empty_handler = self.get_handler('/api/bookstore/')
         expected = {
             'bookstore': True,
-            'version': '2.3.0.dev',
             'validation': {
                 'archive_valid': True,
                 'bookstore_valid': True,
                 'publish_valid': True,
                 'cloning_valid': True,
             },
+            'version': version,
         }
         assert empty_handler.build_response_dict() == expected

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -92,7 +92,7 @@ def bookstore_settings(request):
 
 def test_build_settings_dict(bookstore_settings):
     expected = {
-        'validation': {
+        'features': {
             'archive_valid': True,
             'bookstore_valid': True,
             'publish_valid': True,
@@ -154,7 +154,7 @@ class TestCloneAPIHandler(AsyncTestCase):
     def test_build_response(self):
         empty_handler = self.get_handler('/api/bookstore/')
         expected = {
-            'validation': {
+            'features': {
                 'archive_valid': True,
                 'bookstore_valid': True,
                 'publish_valid': True,

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -96,9 +96,9 @@ def test_build_settings_dict(bookstore_settings):
             'archive_valid': True,
             'bookstore_valid': True,
             'publish_valid': True,
-            'cloning_valid': True,
+            'clone_valid': True,
         },
-        'version': version,
+        'release': version,
     }
     validation = validate_bookstore(bookstore_settings)
     assert expected == build_settings_dict(validation)
@@ -153,13 +153,12 @@ class TestCloneAPIHandler(AsyncTestCase):
     def test_build_response(self):
         empty_handler = self.get_handler('/api/bookstore/')
         expected = {
-            'bookstore': True,
             'validation': {
                 'archive_valid': True,
                 'bookstore_valid': True,
                 'publish_valid': True,
-                'cloning_valid': True,
+                'clone_valid': True,
             },
-            'version': version,
+            'release': version,
         }
         assert empty_handler.build_response_dict() == expected

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -118,3 +118,22 @@ class TestCloneAPIHandler(AsyncTestCase):
             connection=connection,
         )
         return BookstoreVersionHandler(app, payload_request)
+
+    def test_get(self):
+        """This is a simple test of the get API at /api/bookstore
+
+        The most notable feature is the need to set _transforms on the handler.
+
+        The default value of handler()._transforms is `None`.
+        This is iterated over when handler().flush() is called, raising a TypeError.
+        
+        In normal usage, the application assigns this when it creates a handler delegate.
+
+        Because our mock application does not do this 
+        As a result this raises an error when self.finish() (and therefore self.flush()) is called.
+
+        At runtime on a live Jupyter server, application.transforms == [].
+        """
+        get_handler = self.get_handler('/api/bookstore/')
+        setattr(get_handler, '_transforms', [])
+        get_handler.get()

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -69,13 +69,16 @@ def test_collect_handlers_only_version():
     handlers = collect_handlers(log, '/', validation)
     assert expected == handlers
 
-@pytest.fixture
-def bookstore_settings():
+@pytest.fixture(scope="class")
+def bookstore_settings(request):
     mock_settings = {
         "BookstoreSettings": {"s3_access_key_id": "mock_id", "s3_secret_access_key": "mock_access"}
     }
     config = Config(mock_settings)
-    return BookstoreSettings(config=config)
+    bookstore_settings = BookstoreSettings(config=config)
+    if request.cls is not None:
+        request.cls.bookstore_settings = bookstore_settings
+    return bookstore_settings
 
 
 def test_build_settings_dict(bookstore_settings):

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -13,6 +13,7 @@ from traitlets.config import Config
 
 log = logging.getLogger('test_handlers')
 
+from traitlets.config import Config
 
 def test_handlers():
     pass

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -137,3 +137,12 @@ class TestCloneAPIHandler(AsyncTestCase):
         get_handler = self.get_handler('/api/bookstore/')
         setattr(get_handler, '_transforms', [])
         get_handler.get()
+
+    def test_build_response(self):
+        empty_handler = self.get_handler('/api/bookstore/')
+        expected = {
+            'bookstore': True,
+            'validation': {'archive_valid': True, 'bookstore_valid': False, 'publish_valid': True},
+            'version': '2.3.0.dev',
+        }
+        assert empty_handler.build_response_dict() == expected

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -148,7 +148,8 @@ class TestCloneAPIHandler(AsyncTestCase):
         """
         get_handler = self.get_handler('/api/bookstore/')
         setattr(get_handler, '_transforms', [])
-        get_handler.get()
+        return_val = get_handler.get()
+        assert return_val is None
 
     def test_build_response(self):
         empty_handler = self.get_handler('/api/bookstore/')

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -200,7 +200,7 @@ components:
         - bookstore_valid
         - archive_valid
         - publish_valid
-        - cloning_valid
+        - clone_valid
       properties:
         bookstore_valid:
           type: boolean
@@ -208,16 +208,12 @@ components:
           type: boolean
         publish_valid: 
           type: boolean
-        cloning_valid: 
+        clone_valid: 
           type: boolean
     VersionInfo:
       type: object
-      required:
-        - s3path
       properties:
-        bookstore:
-          type: boolean
-        version:
+        release:
           type: string
         validation: 
           $ref: '#/components/schemas/ValidationInfo'

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -197,15 +197,18 @@ components:
     ValidationInfo:
       type: object
       required:
-        - bookstore_validation
-        - archive_validation
-        - published_validation
+        - bookstore_valid
+        - archive_valid
+        - publish_valid
+        - cloning_valid
       properties:
-        bookstore_validation:
+        bookstore_valid:
           type: boolean
-        archive_validation:
+        archive_valid:
           type: boolean
-        published_validation: 
+        publish_valid: 
+          type: boolean
+        cloning_valid: 
           type: boolean
     VersionInfo:
       type: object

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -194,7 +194,7 @@ components:
         format:
           type: string
           description: Format of content (one of null, 'text', 'base64', 'json')
-    ValidationInfo:
+    FeatureValidationInfo:
       type: object
       required:
         - bookstore_valid
@@ -215,5 +215,5 @@ components:
       properties:
         release:
           type: string
-        validation: 
-          $ref: '#/components/schemas/ValidationInfo'
+        features: 
+          $ref: '#/components/schemas/FeatureValidationInfo'


### PR DESCRIPTION
This refactors a bit of the data manipulation code in the handlers into individually testable utils.

This adds tests for the BookstoreVersionHandler.

There are a lot of issues that became obvious as I wrote these tests & helper utils. I will create separate issues for them, but I wanted to list them here. 

1. We should move BookstoreVersionHandler outside of the `handlers.py` module, into it's own module.
2. We could simplify the code without much work. But, the response is being used for validation by front-ends (e.g., nteract_on_jupyter), and so we will need to make sure that this works for them as well. 
Specifically, this would involve removing the `"bookstore": True` bit in the response from the BookstoreVersionHandler
3. Our tests are not all correctly awaiting the asynchronous handler methods, this means our synchronous code in those methods should be tested appropriately, but we'll need to add some more stuff to the other tests to get that working.