### PR TITLE
Refactor & Test Validation and Handler Adding

### DIFF
--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -39,7 +39,7 @@ class BookstoreSettings(LoggingConfigurable):
         config=True
     )
     published_prefix = Unicode("published", help="Prefix for published notebooks").tag(config=True)
-    enable_cloning = Bool(True, help="Explicitly enable or disable cloning.").tag(config=True)
+    enable_cloning = Bool(True, help="Enable cloning.").tag(config=True)
 
     s3_access_key_id = Unicode(
         help="S3/AWS access key ID", allow_none=True, default_value=None

--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -1,5 +1,5 @@
 """Configuration settings for bookstore."""
-from traitlets import Integer, Unicode
+from traitlets import Integer, Unicode, Bool
 from traitlets.config import LoggingConfigurable
 
 
@@ -39,6 +39,7 @@ class BookstoreSettings(LoggingConfigurable):
         config=True
     )
     published_prefix = Unicode("published", help="Prefix for published notebooks").tag(config=True)
+    enable_cloning = Bool(True, help="Explicitly enable or disable cloning.").tag(config=True)
 
     s3_access_key_id = Unicode(
         help="S3/AWS access key ID", allow_none=True, default_value=None
@@ -78,10 +79,12 @@ def validate_bookstore(settings: BookstoreSettings):
     general_settings = [settings.s3_bucket != "", settings.s3_endpoint_url != ""]
     archive_settings = [*general_settings, settings.workspace_prefix != ""]
     published_settings = [*general_settings, settings.published_prefix != ""]
+    cloning_settings = [settings.enable_cloning]
 
     validation_checks = {
         "bookstore_valid": all(general_settings),
         "archive_valid": all(archive_settings),
         "publish_valid": all(published_settings),
+        "cloning_valid": all(cloning_settings),
     }
     return validation_checks

--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -76,8 +76,8 @@ def validate_bookstore(settings: BookstoreSettings):
         Existence of settings by category (general, archive, publish)
     """
     general_settings = [settings.s3_bucket != "", settings.s3_endpoint_url != ""]
-    archive_settings = [settings.workspace_prefix != ""]
-    published_settings = [settings.published_prefix != ""]
+    archive_settings = [*general_settings, settings.workspace_prefix != ""]
+    published_settings = [*general_settings, settings.published_prefix != ""]
 
     validation_checks = {
         "bookstore_valid": all(general_settings),

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -56,7 +56,7 @@ def load_jupyter_server_extension(nb_app):
 def build_handlers(log, base_url, validation):
     """Utility for determinine which handlers should be added to the webapp.
 
-    This returns both the paths that are to be added as well as 
+    This returns each endpoint path and its associated handler.
 
     Parameters
     ----------
@@ -77,7 +77,7 @@ def build_handlers(log, base_url, validation):
     base_bookstore_api_pattern = url_path_join(base_url, '/api/bookstore')
 
     handlers = []
-    # Always enable the version handler
+    # Always enable the version handler for the API
     handlers.append((base_bookstore_api_pattern, BookstoreVersionHandler))
 
     if validation['publish_valid']:
@@ -90,7 +90,7 @@ def build_handlers(log, base_url, validation):
         )
     else:
         log.info(
-            "[bookstore] Not enabling bookstore publishing, s3_bucket or endpoint not configured"
+            "[bookstore] Publishing disabled. s3_bucket or endpoint are not configured."
         )
 
     if validation['cloning_valid']:
@@ -102,6 +102,6 @@ def build_handlers(log, base_url, validation):
             (url_path_join(base_bookstore_pattern, r"/clone(?:/?)*"), BookstoreCloneHandler)
         )
     else:
-        log.info(f"[bookstore] Not enabling bookstore cloning, version: {version}")
+        log.info(f"[bookstore] bookstore cloning disabled, version: {version}")
 
     return handlers

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -49,17 +49,10 @@ def load_jupyter_server_extension(nb_app):
     base_bookstore_api_pattern = url_path_join(web_app.settings['base_url'], '/api/bookstore')
     web_app.add_handlers(host_pattern, [(base_bookstore_api_pattern, BookstoreVersionHandler)])
     bookstore_settings = BookstoreSettings(parent=nb_app)
-    web_app.settings['bookstore'] = {
-        "version": version,
-        "validation": validate_bookstore(bookstore_settings),
-    }
+    validation = validate_bookstore(bookstore_settings)
+    web_app.settings['bookstore'] = {"version": version, "validation": validation}
 
-    check_published = [
-        web_app.settings['bookstore']['validation'].get("bookstore_valid"),
-        web_app.settings['bookstore']['validation'].get("publish_valid"),
-    ]
-
-    if not all(check_published):
+    if not validation['publish_valid']:
         nb_app.log.info("[bookstore] Not enabling bookstore publishing, endpoint not configured")
     else:
         nb_app.log.info(f"[bookstore] Enabling bookstore publishing, version: {version}")
@@ -73,10 +66,14 @@ def load_jupyter_server_extension(nb_app):
             ],
         )
 
-    web_app.add_handlers(
-        host_pattern,
-        [
-            (url_path_join(base_bookstore_api_pattern, r"/clone(?:/?)*"), BookstoreCloneAPIHandler),
-            (url_path_join(base_bookstore_pattern, r"/clone(?:/?)*"), BookstoreCloneHandler),
-        ],
-    )
+    if validation['cloning_valid']:
+        web_app.add_handlers(
+            host_pattern,
+            [
+                (
+                    url_path_join(base_bookstore_api_pattern, r"/clone(?:/?)*"),
+                    BookstoreCloneAPIHandler,
+                ),
+                (url_path_join(base_bookstore_pattern, r"/clone(?:/?)*"), BookstoreCloneHandler),
+            ],
+        )

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -49,14 +49,15 @@ def load_jupyter_server_extension(nb_app):
     bookstore_settings = BookstoreSettings(parent=nb_app)
     validation = validate_bookstore(bookstore_settings)
     web_app.settings['bookstore'] = {"version": version, "validation": validation}
-    handlers = build_handlers(nb_app.log, base_url, validation)
+    handlers = collect_handlers(nb_app.log, base_url, validation)
     web_app.add_handlers(host_pattern, handlers)
 
 
-def build_handlers(log, base_url, validation):
-    """Utility for determinine which handlers should be added to the webapp.
+def collect_handlers(log, base_url, validation):
+    """Utility that collects bookstore endpoints & handlers to be added to the webapp.
 
-    This returns each endpoint path and its associated handler.
+    This uses bookstore feature validation to determine which endpoints should be enabled.
+    It returns all valid pairs of endpoint patterns and handler classes. 
 
     Parameters
     ----------
@@ -71,7 +72,7 @@ def build_handlers(log, base_url, validation):
     --------
     
     List[Tuple[str, tornado.web.RequestHandler]]
-        Template parameters in a dictionary
+      List of pairs of endpoint patterns and the handler used to handle requests at that endpoint.
     """
     base_bookstore_pattern = url_path_join(base_url, '/bookstore')
     base_bookstore_api_pattern = url_path_join(base_url, '/api/bookstore')
@@ -89,9 +90,7 @@ def build_handlers(log, base_url, validation):
             )
         )
     else:
-        log.info(
-            "[bookstore] Publishing disabled. s3_bucket or endpoint are not configured."
-        )
+        log.info("[bookstore] Publishing disabled. s3_bucket or endpoint are not configured.")
 
     if validation['cloning_valid']:
         log.info(f"[bookstore] Enabling bookstore cloning, version: {version}")

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -6,34 +6,71 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 
 def test_validate_bookstore_defaults():
     """Tests that all bookstore validates with default values."""
-    expected = {"bookstore_valid": False, "publish_valid": False, "archive_valid": False}
+    expected = {
+        "bookstore_valid": False,
+        "publish_valid": False,
+        "archive_valid": False,
+        "cloning_valid": True,
+    }
     settings = BookstoreSettings()
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_published():
     """Tests that bookstore does not validate with an empty published_prefix."""
-    expected = {"bookstore_valid": True, "publish_valid": False, "archive_valid": True}
+    expected = {
+        "bookstore_valid": True,
+        "publish_valid": False,
+        "archive_valid": True,
+        "cloning_valid": True,
+    }
     settings = BookstoreSettings(s3_bucket="A_bucket", published_prefix="")
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_workspace():
     """Tests that bookstore does not validate with an empty workspace_prefix."""
-    expected = {"bookstore_valid": True, "publish_valid": True, "archive_valid": False}
+    expected = {
+        "bookstore_valid": True,
+        "publish_valid": True,
+        "archive_valid": False,
+        "cloning_valid": True,
+    }
     settings = BookstoreSettings(s3_bucket="A_bucket", workspace_prefix="")
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_endpoint():
     """Tests that bookstore does not validate with an empty s3_endpoint_url."""
-    expected = {"bookstore_valid": False, "publish_valid": False, "archive_valid": False}
+    expected = {
+        "bookstore_valid": False,
+        "publish_valid": False,
+        "archive_valid": False,
+        "cloning_valid": True,
+    }
     settings = BookstoreSettings(s3_endpoint_url="")
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_bucket():
     """Tests that all bookstore features validate with an s3_bucket."""
-    expected = {"bookstore_valid": True, "publish_valid": True, "archive_valid": True}
+    expected = {
+        "bookstore_valid": True,
+        "publish_valid": True,
+        "archive_valid": True,
+        "cloning_valid": True,
+    }
     settings = BookstoreSettings(s3_bucket="A_bucket")
+    assert validate_bookstore(settings) == expected
+
+
+def test_disable_cloning():
+    """Tests that all bookstore features validate with an s3_bucket."""
+    expected = {
+        "bookstore_valid": True,
+        "publish_valid": True,
+        "archive_valid": True,
+        "cloning_valid": False,
+    }
+    settings = BookstoreSettings(s3_bucket="A_bucket", enable_cloning=False)
     assert validate_bookstore(settings) == expected

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -6,34 +6,34 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 
 def test_validate_bookstore_defaults():
     """Tests that all bookstore validates with default values."""
-    expected = {"bookstore_valid": False, "publish_valid": True, "archive_valid": True}
+    expected = {"bookstore_valid": False, "publish_valid": False, "archive_valid": False}
     settings = BookstoreSettings()
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_published():
     """Tests that bookstore does not validate with an empty published_prefix."""
-    expected = {"bookstore_valid": False, "publish_valid": False, "archive_valid": True}
-    settings = BookstoreSettings(published_prefix="")
+    expected = {"bookstore_valid": True, "publish_valid": False, "archive_valid": True}
+    settings = BookstoreSettings(s3_bucket="A_bucket", published_prefix="")
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_workspace():
     """Tests that bookstore does not validate with an empty workspace_prefix."""
-    expected = {"bookstore_valid": False, "publish_valid": True, "archive_valid": False}
-    settings = BookstoreSettings(workspace_prefix="")
+    expected = {"bookstore_valid": True, "publish_valid": True, "archive_valid": False}
+    settings = BookstoreSettings(s3_bucket="A_bucket", workspace_prefix="")
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_endpoint():
     """Tests that bookstore does not validate with an empty s3_endpoint_url."""
-    expected = {"bookstore_valid": False, "publish_valid": True, "archive_valid": True}
+    expected = {"bookstore_valid": False, "publish_valid": False, "archive_valid": False}
     settings = BookstoreSettings(s3_endpoint_url="")
     assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_bucket():
-    """Tests that bookstore does not validate with an empty s3_bucket."""
+    """Tests that all bookstore features validate with an s3_bucket."""
     expected = {"bookstore_valid": True, "publish_valid": True, "archive_valid": True}
     settings = BookstoreSettings(s3_bucket="A_bucket")
     assert validate_bookstore(settings) == expected

--- a/bookstore/tests/test_bookstore_config.py
+++ b/bookstore/tests/test_bookstore_config.py
@@ -6,31 +6,34 @@ from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 
 def test_validate_bookstore_defaults():
     """Tests that all bookstore validates with default values."""
+    expected = {"bookstore_valid": False, "publish_valid": True, "archive_valid": True}
     settings = BookstoreSettings()
-    assert not validate_bookstore(settings)['bookstore_valid']
-    assert validate_bookstore(settings)['publish_valid']
-    assert validate_bookstore(settings)['archive_valid']
+    assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_published():
     """Tests that bookstore does not validate with an empty published_prefix."""
+    expected = {"bookstore_valid": False, "publish_valid": False, "archive_valid": True}
     settings = BookstoreSettings(published_prefix="")
-    assert not validate_bookstore(settings)['publish_valid']
+    assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_workspace():
     """Tests that bookstore does not validate with an empty workspace_prefix."""
+    expected = {"bookstore_valid": False, "publish_valid": True, "archive_valid": False}
     settings = BookstoreSettings(workspace_prefix="")
-    assert not validate_bookstore(settings)['archive_valid']
+    assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_endpoint():
     """Tests that bookstore does not validate with an empty s3_endpoint_url."""
+    expected = {"bookstore_valid": False, "publish_valid": True, "archive_valid": True}
     settings = BookstoreSettings(s3_endpoint_url="")
-    assert not validate_bookstore(settings)['bookstore_valid']
+    assert validate_bookstore(settings) == expected
 
 
 def test_validate_bookstore_bucket():
     """Tests that bookstore does not validate with an empty s3_bucket."""
+    expected = {"bookstore_valid": True, "publish_valid": True, "archive_valid": True}
     settings = BookstoreSettings(s3_bucket="A_bucket")
-    assert validate_bookstore(settings)['bookstore_valid']
+    assert validate_bookstore(settings) == expected

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -1,14 +1,12 @@
 """Tests for handlers"""
 import pytest
 import logging
-
 from unittest.mock import Mock
 
 from bookstore.handlers import build_handlers, BookstoreVersionHandler
 from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 from bookstore.clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
 from bookstore.publish import BookstorePublishHandler
-
 from notebook.base.handlers import path_regex
 from tornado.web import Application
 from traitlets.config import Config

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -3,7 +3,7 @@ import pytest
 import logging
 from unittest.mock import Mock
 
-from bookstore.handlers import build_handlers, BookstoreVersionHandler
+from bookstore.handlers import collect_handlers, BookstoreVersionHandler
 from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 from bookstore.clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
 from bookstore.publish import BookstorePublishHandler
@@ -18,57 +18,53 @@ def test_handlers():
     pass
 
 
-def test_build_handlers_all():
+def test_collect_handlers_all():
+    expected = [
+        ('/api/bookstore', BookstoreVersionHandler),
+        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
+        ('/api/bookstore/clone(?:/?)*', BookstoreCloneAPIHandler),
+        ('/bookstore/clone(?:/?)*', BookstoreCloneHandler),
+    ]
     web_app = Application()
     mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket"}}
     bookstore_settings = BookstoreSettings(config=Config(mock_settings))
     validation = validate_bookstore(bookstore_settings)
-    handlers = build_handlers(log, '/', validation)
-    expected = [
-        ('/api/bookstore', BookstoreVersionHandler),
-        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
-        ('/api/bookstore/clone(?:/?)*', BookstoreCloneAPIHandler),
-        ('/bookstore/clone(?:/?)*', BookstoreCloneHandler),
-    ]
-
+    handlers = collect_handlers(log, '/', validation)
     assert expected == handlers
 
 
-def test_build_handlers_no_clone():
+def test_collect_handlers_no_clone():
+    expected = [
+        ('/api/bookstore', BookstoreVersionHandler),
+        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
+    ]
     web_app = Application()
     mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket", "enable_cloning": False}}
     bookstore_settings = BookstoreSettings(config=Config(mock_settings))
     validation = validate_bookstore(bookstore_settings)
-    handlers = build_handlers(log, '/', validation)
-    expected = [
-        ('/api/bookstore', BookstoreVersionHandler),
-        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
-    ]
-
+    handlers = collect_handlers(log, '/', validation)
     assert expected == handlers
 
 
-def test_build_handlers_no_publish():
-    web_app = Application()
-    mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket", "published_prefix": ""}}
-    bookstore_settings = BookstoreSettings(config=Config(mock_settings))
-    validation = validate_bookstore(bookstore_settings)
-    handlers = build_handlers(log, '/', validation)
+def test_collect_handlers_no_publish():
     expected = [
         ('/api/bookstore', BookstoreVersionHandler),
         ('/api/bookstore/clone(?:/?)*', BookstoreCloneAPIHandler),
         ('/bookstore/clone(?:/?)*', BookstoreCloneHandler),
     ]
-
+    web_app = Application()
+    mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket", "published_prefix": ""}}
+    bookstore_settings = BookstoreSettings(config=Config(mock_settings))
+    validation = validate_bookstore(bookstore_settings)
+    handlers = collect_handlers(log, '/', validation)
     assert expected == handlers
 
 
-def test_build_handlers_only_version():
+def test_collect_handlers_only_version():
+    expected = [('/api/bookstore', BookstoreVersionHandler)]
     web_app = Application()
     mock_settings = {"BookstoreSettings": {"enable_cloning": False}}
     bookstore_settings = BookstoreSettings(config=Config(mock_settings))
     validation = validate_bookstore(bookstore_settings)
-    handlers = build_handlers(log, '/', validation)
-    expected = [('/api/bookstore', BookstoreVersionHandler)]
-
+    handlers = collect_handlers(log, '/', validation)
     assert expected == handlers

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -1,6 +1,76 @@
 """Tests for handlers"""
 import pytest
+import logging
+
+from unittest.mock import Mock
+
+from bookstore.handlers import build_handlers, BookstoreVersionHandler
+from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
+from bookstore.clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
+from bookstore.publish import BookstorePublishHandler
+
+from notebook.base.handlers import path_regex
+from tornado.web import Application
+from traitlets.config import Config
+
+log = logging.getLogger('test_handlers')
 
 
 def test_handlers():
     pass
+
+
+def test_build_handlers_all():
+    web_app = Application()
+    mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket"}}
+    bookstore_settings = BookstoreSettings(config=Config(mock_settings))
+    validation = validate_bookstore(bookstore_settings)
+    handlers = build_handlers(log, '/', validation)
+    expected = [
+        ('/api/bookstore', BookstoreVersionHandler),
+        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
+        ('/api/bookstore/clone(?:/?)*', BookstoreCloneAPIHandler),
+        ('/bookstore/clone(?:/?)*', BookstoreCloneHandler),
+    ]
+
+    assert expected == handlers
+
+
+def test_build_handlers_no_clone():
+    web_app = Application()
+    mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket", "enable_cloning": False}}
+    bookstore_settings = BookstoreSettings(config=Config(mock_settings))
+    validation = validate_bookstore(bookstore_settings)
+    handlers = build_handlers(log, '/', validation)
+    expected = [
+        ('/api/bookstore', BookstoreVersionHandler),
+        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
+    ]
+
+    assert expected == handlers
+
+
+def test_build_handlers_no_publish():
+    web_app = Application()
+    mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket", "published_prefix": ""}}
+    bookstore_settings = BookstoreSettings(config=Config(mock_settings))
+    validation = validate_bookstore(bookstore_settings)
+    handlers = build_handlers(log, '/', validation)
+    expected = [
+        ('/api/bookstore', BookstoreVersionHandler),
+        ('/api/bookstore/clone(?:/?)*', BookstoreCloneAPIHandler),
+        ('/bookstore/clone(?:/?)*', BookstoreCloneHandler),
+    ]
+
+    assert expected == handlers
+
+
+def test_build_handlers_only_version():
+    web_app = Application()
+    mock_settings = {"BookstoreSettings": {"enable_cloning": False}}
+    bookstore_settings = BookstoreSettings(config=Config(mock_settings))
+    validation = validate_bookstore(bookstore_settings)
+    handlers = build_handlers(log, '/', validation)
+    expected = [('/api/bookstore', BookstoreVersionHandler)]
+
+    assert expected == handlers

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ flake8
 mock
 mypy==0.660  # pin to avoid surprises
 pre-commit
-pytest>=3.3
+pytest>=3.6
 pytest-asyncio
 pytest-cov
 pytest-mock


### PR DESCRIPTION
The biggest win in this is that this tests which endpoints & handlers are actually enabled in the handlers module. #130 does not address this, and should probably be rebased on top of this if this is merged.

- adds a way to disable cloning via `BookstoreSettings.cloning_enabled` traitlet
- adds `cloning_enabled` to validation code
- adds a new `build_handlers` function so we can test it directly (allowing less mocking)
- changes the semantics of `publish_enabled` and `archive_enabled`
- updates our `pytest` requirement to include `pytest>=3.6` (as required by `pytest-asyncio` as reported in [this issue](pytest-dev/pytest-asyncio#115))