### PR TITLE
Publish test

### DIFF
--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -150,7 +150,7 @@ class BookstoreCloneAPIHandler(APIHandler):
             "mimetype": "text/plain",
             "content": content.decode('utf-8'),
         }
-        self.set_status(201)
+        self.set_status(obj['ResponseMetadata']['HTTPStatusCode'])
 
         if 'VersionId' in obj:
             resp_content["versionID"] = obj['VersionId']

--- a/bookstore/handlers.py
+++ b/bookstore/handlers.py
@@ -9,7 +9,7 @@ from tornado import web
 from ._version import __version__
 from .bookstore_config import BookstoreSettings
 from .bookstore_config import validate_bookstore
-from .publish import BookstorePublishHandler
+from .publish import BookstorePublishAPIHandler
 from .clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
 
 
@@ -86,7 +86,7 @@ def collect_handlers(log, base_url, validation):
         handlers.append(
             (
                 url_path_join(base_bookstore_api_pattern, r"/publish%s" % path_regex),
-                BookstorePublishHandler,
+                BookstorePublishAPIHandler,
             )
         )
     else:

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -11,7 +11,7 @@ from .s3_paths import s3_display_path
 from .utils import url_path_join
 
 
-class BookstorePublishHandler(APIHandler):
+class BookstorePublishAPIHandler(APIHandler):
     """Publish a notebook to the publish path"""
 
     def initialize(self):

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -45,10 +45,14 @@ class BookstorePublishAPIHandler(APIHandler):
         self.finish(resp)
 
     def validate_model(self, model):
-        """This is a helper that validates that the model meets the notebook Contents API.
+        """This is a helper that validates that the model meets our expected structure.
 
-        It uses the validate_model method provided in the contents API handler.
+        Raises
+        ------
+        tornado.web.HTTPError
+            Your model does not validate correctly
         """
+        # TODO: This is far more lenient than our API docs would suggest. We should reconcile them.
         if model['type'] != 'notebook':
             raise web.HTTPError(400, "bookstore only publishes notebooks")
 

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -43,7 +43,7 @@ class BookstorePublishAPIHandler(APIHandler):
         self.finish(resp)
 
     def validate_model(self, model):
-        """This is a helper that validates that the model meets our expected structure.
+        """Checks that the model given to the API handler meets bookstore's expected structure for a notebook.
 
         Pattern for surfacing nbformat validation errors originally written in
         https://github.com/jupyter/notebook/blob/a44a367c219b60a19bee003877d32c3ff1ce2412/notebook/services/contents/manager.py#L353-L355

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -40,7 +40,6 @@ class BookstorePublishAPIHandler(APIHandler):
         model = self.get_json_body()
         self.validate_model(model)
         resp = await self._publish(model['content'], path.lstrip('/'))
-        self.set_status(201)
         self.finish(resp)
 
     def validate_model(self, model):
@@ -103,6 +102,7 @@ class BookstorePublishAPIHandler(APIHandler):
             self.log.info("Done with published write of %s", path)
 
         resp_content = self.prepare_response(path, obj)
+        self.set_status(obj['ResponseMetadata']['HTTPStatusCode'])
         return json.dumps(resp_content)
 
     def prepare_response(self, path, obj):

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -56,16 +56,16 @@ class BookstorePublishAPIHandler(APIHandler):
         if not model:
             raise web.HTTPError(400, "Bookstore cannot publish an empty model")
         if model.get('type', "") != 'notebook':
-            raise web.HTTPError(400, "Bookstore only publishes notebooks")
+            raise web.HTTPError(415, "Bookstore only publishes notebooks")
 
         content = model.get('content', {})
         if content == {}:
-            raise web.HTTPError(400, "Bookstore cannot publish empty contents")
+            raise web.HTTPError(422, "Bookstore cannot publish empty contents")
         try:
             validate_nb(content)
         except ValidationError as e:
             raise web.HTTPError(
-                400,
+                422,
                 "Bookstore cannot publish invalid notebook. "
                 "Validation errors are as follows: "
                 f"{e.message} {json.dumps(e.instance, indent=1, default=lambda obj: '<UNKNOWN>')}",

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -3,7 +3,8 @@ import json
 import aiobotocore
 
 from botocore.exceptions import ClientError
-from nbformat import ValidationError, validate as validate_nb
+from nbformat import ValidationError
+from nbformat import validate as validate_nb
 from notebook.base.handlers import APIHandler, path_regex
 from notebook.services.contents.handlers import validate_model
 from tornado import web
@@ -102,8 +103,7 @@ class BookstorePublishAPIHandler(APIHandler):
             self.log.info("Done with published write of %s", path)
 
         resp_content = self.prepare_response(path, obj)
-        resp_str = json.dumps(resp_content)
-        return resp_str
+        return json.dumps(resp_content)
 
     def prepare_response(self, path, obj):
 

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -35,13 +35,7 @@ class BookstorePublishAPIHandler(APIHandler):
 
         model = self.get_json_body()
         self.validate_model(model)
-        content = model['content']
-
-        if model:
-            resp = await self._publish(content, path.lstrip('/'))
-        else:
-            raise web.HTTPError(400, "Cannot publish an empty model")
-
+        resp = await self._publish(model['content'], path.lstrip('/'))
         self.finish(resp)
 
     def validate_model(self, model):
@@ -53,8 +47,10 @@ class BookstorePublishAPIHandler(APIHandler):
             Your model does not validate correctly
         """
         # TODO: This is far more lenient than our API docs would suggest. We should reconcile them.
-        if model['type'] != 'notebook':
-            raise web.HTTPError(400, "bookstore only publishes notebooks")
+        if not model:
+            raise web.HTTPError(400, "Bookstore cannot publish an empty model")
+        if model.get('type', "") != 'notebook':
+            raise web.HTTPError(400, "Bookstore only publishes notebooks")
 
     def prepare_paths(self, path):
         full_s3_path = s3_path(

--- a/bookstore/tests/test_handlers.py
+++ b/bookstore/tests/test_handlers.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 from bookstore.handlers import collect_handlers, BookstoreVersionHandler
 from bookstore.bookstore_config import BookstoreSettings, validate_bookstore
 from bookstore.clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
-from bookstore.publish import BookstorePublishHandler
+from bookstore.publish import BookstorePublishAPIHandler
 from notebook.base.handlers import path_regex
 from tornado.web import Application
 from traitlets.config import Config
@@ -21,7 +21,7 @@ def test_handlers():
 def test_collect_handlers_all():
     expected = [
         ('/api/bookstore', BookstoreVersionHandler),
-        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
+        ('/api/bookstore/publish%s' % path_regex, BookstorePublishAPIHandler),
         ('/api/bookstore/clone(?:/?)*', BookstoreCloneAPIHandler),
         ('/bookstore/clone(?:/?)*', BookstoreCloneHandler),
     ]
@@ -36,7 +36,7 @@ def test_collect_handlers_all():
 def test_collect_handlers_no_clone():
     expected = [
         ('/api/bookstore', BookstoreVersionHandler),
-        ('/api/bookstore/publish%s' % path_regex, BookstorePublishHandler),
+        ('/api/bookstore/publish%s' % path_regex, BookstorePublishAPIHandler),
     ]
     web_app = Application()
     mock_settings = {"BookstoreSettings": {"s3_bucket": "mock_bucket", "enable_cloning": False}}

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -57,3 +57,11 @@ class TestPublishAPIHandler(AsyncTestCase):
         empty_handler = self.put_handler('/bookstore/publish/hi')
         with pytest.raises(HTTPError):
             await empty_handler.put('hi')
+
+    @gen_test
+    async def test_put_bad_body(self):
+        body_dict = {'content': 2}
+        empty_handler = self.put_handler('/bookstore/publish/hi', body_dict=body_dict)
+        with pytest.raises(HTTPError):
+            await empty_handler.put('hi')
+

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -45,3 +45,15 @@ class TestPublishAPIHandler(AsyncTestCase):
             connection=connection,
         )
         return BookstorePublishAPIHandler(app, payload_request)
+
+    @gen_test
+    async def test_put_no_path(self):
+        empty_handler = self.put_handler('/bookstore/publish/')
+        with pytest.raises(HTTPError):
+            await empty_handler.put('')
+
+    @gen_test
+    async def test_put_no_body(self):
+        empty_handler = self.put_handler('/bookstore/publish/hi')
+        with pytest.raises(HTTPError):
+            await empty_handler.put('hi')

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -1,9 +1,47 @@
 import asyncio
+import json
+
+from unittest.mock import Mock
+
 import pytest
 
 from bookstore.publish import BookstorePublishAPIHandler
+from tornado.testing import AsyncTestCase, gen_test
+from tornado.web import Application, HTTPError
+from tornado.httpserver import HTTPRequest
+from traitlets.config import Config
 
 
 def test_create_publish_handler_no_params():
     with pytest.raises(TypeError):
         assert BookstorePublishAPIHandler()
+
+
+class TestPublishAPIHandler(AsyncTestCase):
+    def setUp(self):
+        super().setUp()
+        mock_settings = {
+            "BookstoreSettings": {
+                "s3_access_key_id": "mock_id",
+                "s3_secret_access_key": "mock_access",
+            }
+        }
+        config = Config(mock_settings)
+
+        self.mock_application = Mock(spec=Application, ui_methods={}, ui_modules={}, settings={})
+
+    def put_handler(self, uri, body_dict=None, app=None):
+        if body_dict is None:
+            body_dict = {}
+        if app is None:
+            app = self.mock_application
+        connection = Mock(context=Mock(protocol="https"))
+        body = json.dumps(body_dict).encode('utf-8')
+        payload_request = HTTPRequest(
+            method='PUT',
+            uri=uri,
+            headers={"Host": "localhost:8888"},
+            body=body,
+            connection=connection,
+        )
+        return BookstorePublishAPIHandler(app, payload_request)

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -53,15 +53,15 @@ class TestPublishAPIHandler(AsyncTestCase):
 
     @gen_test
     async def test_put_no_path(self):
-        empty_handler = self.put_handler('/bookstore/publish/')
+        no_path_handler = self.put_handler('/bookstore/publish/')
         with pytest.raises(HTTPError):
-            await empty_handler.put('')
+            await no_path_handler.put('')
 
     @gen_test
     async def test_put_no_body(self):
-        empty_handler = self.put_handler('/bookstore/publish/hi')
+        no_body_handler = self.put_handler('/bookstore/publish/hi')
         with pytest.raises(HTTPError):
-            await empty_handler.put('hi')
+            await no_body_handler.put('hi')
 
     @gen_test
     async def test_put_s3_error(self):

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -1,9 +1,9 @@
 import asyncio
 import pytest
 
-from bookstore.publish import BookstorePublishHandler
+from bookstore.publish import BookstorePublishAPIHandler
 
 
 def test_create_publish_handler_no_params():
     with pytest.raises(TypeError):
-        assert BookstorePublishHandler()
+        assert BookstorePublishAPIHandler()

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from bookstore.publish import BookstorePublishAPIHandler
+from nbformat.v4 import new_notebook
 from tornado.testing import AsyncTestCase, gen_test
 from tornado.web import Application, HTTPError
 from tornado.httpserver import HTTPRequest
@@ -63,14 +64,46 @@ class TestPublishAPIHandler(AsyncTestCase):
             await empty_handler.put('hi')
 
     @gen_test
-    async def test_put_bad_body(self):
-        body_dict = {'content': 2}
-        bad_body_handler = self.put_handler('/bookstore/publish/hi', body_dict=body_dict)
+    async def test_put_s3_error(self):
+        """this test includes a valid body so that we get to the s3 part of our system"""
+        body_dict = {'content': new_notebook(), 'type': "notebook"}
+        ok_body_handler = self.put_handler('/bookstore/publish/hi', body_dict=body_dict)
         with pytest.raises(HTTPError):
-            await bad_body_handler.put('hi')
+            await ok_body_handler.put('hi')
 
     def test_prepare_response(self):
         expected = {"s3path": "my_bucket/custom_prefix/mylocal/path", "versionID": "eeeeAB"}
         empty_handler = self.put_handler('/bookstore/publish/hi')
         actual = empty_handler.prepare_response("mylocal/path", {"VersionId": "eeeeAB"})
         assert actual == expected
+
+    def test_validate_model_no_type(self):
+        body_dict = {'content': {}}
+        empty_handler = self.put_handler('/bookstore/publish/hi')
+        with pytest.raises(HTTPError):
+            empty_handler.validate_model(body_dict)
+
+    def test_validate_model_wrong_type(self):
+        body_dict = {'content': {}, 'type': "file"}
+        empty_handler = self.put_handler('/bookstore/publish/hi')
+        with pytest.raises(HTTPError):
+            empty_handler.validate_model(body_dict)
+
+    def test_validate_model_empty_content(self):
+        body_dict = {'content': {}, 'type': "notebook"}
+        empty_handler = self.put_handler('/bookstore/publish/hi')
+        with pytest.raises(HTTPError):
+            empty_handler.validate_model(body_dict)
+
+    def test_validate_model_bad_notebook(self):
+        bad_notebook = new_notebook()
+        bad_notebook['other_field'] = "hello"
+        body_dict = {'content': bad_notebook, 'type': "notebook"}
+        empty_handler = self.put_handler('/bookstore/publish/hi')
+        with pytest.raises(HTTPError):
+            empty_handler.validate_model(body_dict)
+
+    def test_validate_model_good_notebook(self):
+        body_dict = {'content': new_notebook(), 'type': "notebook"}
+        empty_handler = self.put_handler('/bookstore/publish/hi')
+        empty_handler.validate_model(body_dict)

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -67,7 +67,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/S3CloneFile'
+              $ref: '#/components/schemas/S3CloneFileRequest'
         required: true
       responses:
         200:
@@ -96,7 +96,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Contents'
+              $ref: '#/components/schemas/PublishableContents'
         required: true
       
       responses:
@@ -105,11 +105,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/S3PublishFile'
+                $ref: '#/components/schemas/S3PublishFileResponse'
 
 components:
   schemas:
-    S3CloneFile:
+    S3CloneFileRequest:
       type: object
       required: 
         - s3_bucket
@@ -121,7 +121,7 @@ components:
           type: string
         target_path:
           type: string
-    S3PublishFile:
+    S3PublishFileResponse:
       type: object
       required:
         - s3path
@@ -130,6 +130,20 @@ components:
           type: string
         versionID:
           type: string
+    PublishableContents: 
+      description: "A object representing contents that can be published. This is currently a subset of the fields required for the Contents API."
+      type: object
+      required:
+        - type
+        - content
+      properties:
+        type:
+          type: string
+          description: Type of content
+          enum:
+            - notebook
+        content:
+          $ref: https://raw.githubusercontent.com/jupyter/nbformat/master/nbformat/v4/nbformat.v4.schema.json
     Contents:
       description: "A contents object.  The content and format keys may be null if content is not contained.  If type is 'file', then the mimetype will be null."
       type: object

--- a/docs/source/reference/publish.rst
+++ b/docs/source/reference/publish.rst
@@ -6,14 +6,14 @@ The ``publish`` module
 
 .. module:: bookstore.publish
 
-``BookstorePublishHandler``
+``BookstorePublishAPIHandler``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: BookstorePublishHandler
+.. autoclass:: BookstorePublishAPIHandler
 
 Methods
 ^^^^^^^
 
-.. automethod:: BookstorePublishHandler.initialize
+.. automethod:: BookstorePublishAPIHandler.initialize
 
-.. automethod:: BookstorePublishHandler.post
+.. automethod:: BookstorePublishAPIHandler.post


### PR DESCRIPTION
This PR grew a bit, however the core of it is the creation of new publish handler tests.

It also refactors some of the code so it is more encapsulated and testable.

Because I realized as I was going through the tests that we weren't doing a great job of catching invalid request bodies, It also adds better validation around those.

That then led to a realization that our API docs were not appropriately specific about the request body.
Specifically, it said it needed to be a Contents API compatible message, but that wasn't the case. Furthermore, that behaviour doesn't match the APIs expected in the current notebook's contents handlers. 