### PR TITLE
Clone Refactor & Test improvements

### DIFF
--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -24,10 +24,10 @@ def build_notebook_model(content, path):
 
     Parameters
     ----------
-    model : str
-        The content we wish to clone. 
+    content : str
+        The content of the model.
     path : str
-        The the path we wish to clone to.
+        The path to be targeted.
 
     Returns
     --------
@@ -49,10 +49,10 @@ def build_file_model(content, path):
 
     Parameters
     ----------
-    model : str
-        The content we wish to clone. 
+    content: str
+        The content of the model
     path : str
-        The the path we wish to clone to.
+        The path to be targeted.
 
     Returns
     --------
@@ -157,6 +157,10 @@ class BookstoreCloneAPIHandler(APIHandler):
         Helper to access bookstore settings.
     post(self)
         Clone a notebook from the location specified by the payload.
+    build_content_model(self, obj, path)
+        Helper that takes a response from S3 and creates a ContentsAPI compatible model.
+    build_post_response_model(self, model, obj, s3_bucket, s3_object_key)
+        Helper that takes a Jupyter Contents API compliant model and adds cloning specific information.
 
     See also
     --------

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -19,6 +19,56 @@ from .utils import url_path_join
 BOOKSTORE_FILE_LOADER = FileSystemLoader(PACKAGE_DIR)
 
 
+def build_notebook_model(content, path):
+    """Helper that builds a Contents API compatible model for notebooks.
+
+    Parameters
+    ----------
+    model : str
+        The content we wish to clone. 
+    path : str
+        The the path we wish to clone to.
+
+    Returns
+    --------
+    dict
+        Jupyter Contents API compatible model for notebooks
+    """
+    model = {
+        "type": "notebook",
+        "format": "json",
+        "content": json.loads(content),
+        "name": os.path.basename(os.path.relpath(path)),
+        "path": os.path.relpath(path),
+    }
+    return model
+
+
+def build_file_model(content, path):
+    """Helper that builds a Contents API compatible model for files.
+
+    Parameters
+    ----------
+    model : str
+        The content we wish to clone. 
+    path : str
+        The the path we wish to clone to.
+
+    Returns
+    --------
+    dict
+        Jupyter Contents API compatible model for files
+    """
+    model = {
+        "type": "file",
+        "format": "text",
+        "content": content,
+        "name": os.path.basename(os.path.relpath(path)),
+        "path": os.path.relpath(path),
+    }
+    return model
+
+
 class BookstoreCloneHandler(IPythonHandler):
     """Prepares and provides clone options page, populating UI with clone option parameters.
 
@@ -216,57 +266,9 @@ class BookstoreCloneAPIHandler(APIHandler):
         content = await obj['Body'].read()
         content = content.decode('utf-8')
         if os.path.splitext(path)[1] in [".ipynb", ".jpynb"]:
-            model = self.build_notebook_model(content, path)
+            model = build_notebook_model(content, path)
         else:
-            model = self.build_file_model(content, path)
-        return model
-
-    def build_notebook_model(self, content, path):
-        """Helper that builds a Contents API compatible model for notebooks.
-
-        Parameters
-        ----------
-        model : str
-            The content we wish to clone. 
-        path : str
-            The the path we wish to clone to.
-
-        Returns
-        --------
-        dict
-            Jupyter Contents API compatible model for notebooks
-        """
-        model = {
-            "type": "notebook",
-            "format": "json",
-            "content": json.loads(content),
-            "name": os.path.basename(os.path.relpath(path)),
-            "path": os.path.relpath(path),
-        }
-        return model
-
-    def build_file_model(self, content, path):
-        """Helper that builds a Contents API compatible model for files.
-
-        Parameters
-        ----------
-        model : str
-            The content we wish to clone. 
-        path : str
-            The the path we wish to clone to.
-
-        Returns
-        --------
-        dict
-            Jupyter Contents API compatible model for files
-        """
-        model = {
-            "type": "file",
-            "format": "text",
-            "content": content,
-            "name": os.path.basename(os.path.relpath(path)),
-            "path": os.path.relpath(path),
-        }
+            model = build_file_model(content, path)
         return model
 
     def build_post_response_model(self, model, obj, s3_bucket):

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -225,7 +225,7 @@ class TestCloneAPIHandler(AsyncTestCase):
         assert actual == expected
 
     @gen_test
-    async def test_build_content_model(self):
+    async def test_build_text_content_model(self):
         content = "some content"
         expected = {
             "type": "file",
@@ -244,6 +244,30 @@ class TestCloneAPIHandler(AsyncTestCase):
 
         obj = {'Body': MyFakeClass()}
         path = "test_directory/file_name.txt"
+        success_handler = self.post_handler({})
+        model = await success_handler.build_content_model(obj, path)
+        assert model == expected
+
+    @gen_test
+    async def test_build_notebook_content_model(self):
+        content = nbformat.v4.new_notebook()
+        expected = {
+            "type": "notebook",
+            "format": "json",
+            "content": content,
+            "name": "file_name.ipynb",
+            "path": "test_directory/file_name.ipynb",
+        }
+
+        class MyFakeClass:
+            def __init__(self):
+                pass
+
+            async def read(self):
+                return nbformat.writes(content).encode('utf-8')
+
+        obj = {'Body': MyFakeClass()}
+        path = "test_directory/file_name.ipynb"
         success_handler = self.post_handler({})
         model = await success_handler.build_content_model(obj, path)
         assert model == expected

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import Mock
 
 import pytest
+import nbformat
 
 from jinja2 import Environment
 from tornado.testing import AsyncTestCase, gen_test
@@ -11,7 +12,39 @@ from tornado.httpserver import HTTPRequest
 from traitlets.config import Config
 
 
-from ..clone import BookstoreCloneHandler, BookstoreCloneAPIHandler
+from bookstore.clone import (
+    build_notebook_model,
+    build_file_model,
+    BookstoreCloneHandler,
+    BookstoreCloneAPIHandler,
+)
+
+
+def test_build_notebook_model():
+    content = nbformat.v4.new_notebook()
+    expected = {
+        "type": "notebook",
+        "format": "json",
+        "content": content,
+        "name": "my_notebook_name.ipynb",
+        "path": "test_directory/my_notebook_name.ipynb",
+    }
+    path = "./test_directory/my_notebook_name.ipynb"
+    nb_content = nbformat.writes(content)
+    assert build_notebook_model(nb_content, path) == expected
+
+
+def test_build_file_model():
+    content = "my fancy file"
+    expected = {
+        "type": "file",
+        "format": "text",
+        "content": content,
+        "name": "file_name.txt",
+        "path": "test_directory/file_name.txt",
+    }
+    path = "./test_directory/file_name.txt"
+    assert build_file_model(content, path) == expected
 
 
 class TestCloneHandler(AsyncTestCase):

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -192,3 +192,29 @@ class TestCloneAPIHandler(AsyncTestCase):
         success_handler = self.post_handler(post_body_dict)
         with pytest.raises(HTTPError):
             await success_handler._clone(s3_bucket, s3_object_key)
+
+    def test_build_post_response_model(self):
+        content = "some arbitrary content"
+        expected = {
+            "type": "file",
+            "format": "text",
+            "content": content,
+            "name": "file_name.txt",
+            "path": "test_directory/file_name.txt",
+            "s3_path": "s3://my_bucket/original_key/may_be_different_than_storage.txt",
+            'versionID': "eeee222eee",
+        }
+
+        s3_bucket = "my_bucket"
+        s3_object_key = "original_key/may_be_different_than_storage.txt"
+        obj = {'VersionId': "eeee222eee"}
+        model = {
+            "type": "file",
+            "format": "text",
+            "content": content,
+            "name": "file_name.txt",
+            "path": "test_directory/file_name.txt",
+        }
+        handler = self.post_handler({})
+        actual = handler.build_post_response_model(model, obj, s3_bucket, s3_object_key)
+        assert actual == expected

--- a/docs/source/reference/clone.rst
+++ b/docs/source/reference/clone.rst
@@ -6,6 +6,10 @@ The ``clone`` module
 
 .. module:: bookstore.clone
 
+.. autofunction:: build_notebook_model
+
+.. autofunction:: build_file_model
+
 ``BookstoreCloneHandler``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -34,4 +38,6 @@ Methods
 
 .. automethod:: BookstoreCloneAPIHandler.post
 
-.. automethod:: BookstoreCloneAPIHandler.build_post_model_response
+.. automethod:: BookstoreCloneAPIHandler.build_content_model
+
+.. automethod:: BookstoreCloneAPIHandler.build_post_response_model


### PR DESCRIPTION
I wanted to set us up for success going forward around cloning.  

The difficulty we were having getting coverage in the tests suggested to me that we hadn't properly isolated the different pieces of the logic. When I started diving in it became clear that the internal logic of the clone API handler could use a lot of attention & refactoring.

Once the refactor was done it was fairly straightforward to test. 

Also made general improvements

- Docstring improvements
- Distinguish between notebooks and files (previously we were treating all types of content identically)
- we weren't returning the s3 relevant info we were recording (which means changing the response API

Overall the code should be much easier to follow.