### PR TITLE
Publish refactor

### DIFF
--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -111,19 +111,19 @@ class BookstorePublishAPIHandler(APIHandler):
                 raise web.HTTPError(status_code, e.args[0])
             self.log.info("Done with published write of %s", path)
 
-        resp_content = self.prepare_response(path, obj)
+        resp_content = self.prepare_response(obj, path)
         self.set_status(obj['ResponseMetadata']['HTTPStatusCode'])
         return json.dumps(resp_content)
 
-    def prepare_response(self, path, obj):
+    def prepare_response(self, obj, path):
         """Prepares repsonse to publish PUT request.
 
         Parameters
         ----------
-        path: 
-            path to place after the published prefix in the designated bucket
         obj: dict
             Validation dictionary for determining which endpoints to enable.
+        path: 
+            path to place after the published prefix in the designated bucket
 
         Returns
         --------

--- a/bookstore/publish.py
+++ b/bookstore/publish.py
@@ -31,6 +31,11 @@ class BookstorePublishAPIHandler(APIHandler):
         PUT /api/bookstore/publish
 
         The payload directly matches the contents API for PUT.
+
+        Parameters
+        ----------
+        path: str
+            Path describing where contents should be published to, postfixed to the published_prefix .
         """
         self.log.info("Attempt publishing to %s", path)
 
@@ -47,6 +52,11 @@ class BookstorePublishAPIHandler(APIHandler):
 
         Pattern for surfacing nbformat validation errors originally written in
         https://github.com/jupyter/notebook/blob/a44a367c219b60a19bee003877d32c3ff1ce2412/notebook/services/contents/manager.py#L353-L355
+
+        Parameters
+        ----------
+        model: dict
+            Request model for publishing describing the type and content of the object.
 
         Raises
         ------
@@ -106,6 +116,20 @@ class BookstorePublishAPIHandler(APIHandler):
         return json.dumps(resp_content)
 
     def prepare_response(self, path, obj):
+        """Prepares repsonse to publish PUT request.
+
+        Parameters
+        ----------
+        path: 
+            path to place after the published prefix in the designated bucket
+        obj: dict
+            Validation dictionary for determining which endpoints to enable.
+
+        Returns
+        --------
+        dict
+            Model for responding to put request. 
+        """
 
         full_s3_path = s3_path(
             self.bookstore_settings.s3_bucket, self.bookstore_settings.published_prefix, path

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -72,9 +72,11 @@ class TestPublishAPIHandler(AsyncTestCase):
             await ok_body_handler.put('hi')
 
     def test_prepare_response(self):
-        expected = {"s3path": "my_bucket/custom_prefix/mylocal/path", "versionID": "eeeeAB"}
+        expected = {"s3_path": "s3://my_bucket/custom_prefix/mylocal/path", "versionID": "eeeeAB"}
         empty_handler = self.put_handler('/bookstore/publish/hi')
-        actual = empty_handler.prepare_response({"VersionId": "eeeeAB"}, "mylocal/path")
+        actual = empty_handler.prepare_response(
+            {"VersionId": "eeeeAB"}, "s3://my_bucket/custom_prefix/mylocal/path"
+        )
         assert actual == expected
 
     def test_validate_model_no_type(self):

--- a/bookstore/tests/test_publish.py
+++ b/bookstore/tests/test_publish.py
@@ -74,7 +74,7 @@ class TestPublishAPIHandler(AsyncTestCase):
     def test_prepare_response(self):
         expected = {"s3path": "my_bucket/custom_prefix/mylocal/path", "versionID": "eeeeAB"}
         empty_handler = self.put_handler('/bookstore/publish/hi')
-        actual = empty_handler.prepare_response("mylocal/path", {"VersionId": "eeeeAB"})
+        actual = empty_handler.prepare_response({"VersionId": "eeeeAB"}, "mylocal/path")
         assert actual == expected
 
     def test_validate_model_no_type(self):

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -124,9 +124,9 @@ components:
     S3PublishFileResponse:
       type: object
       required:
-        - s3path
+        - s3_path
       properties:
-        s3path:
+        s3_path:
           type: string
         versionID:
           type: string

--- a/docs/source/reference/publish.rst
+++ b/docs/source/reference/publish.rst
@@ -7,7 +7,7 @@ The ``publish`` module
 .. module:: bookstore.publish
 
 ``BookstorePublishAPIHandler``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: BookstorePublishAPIHandler
 
@@ -16,4 +16,8 @@ Methods
 
 .. automethod:: BookstorePublishAPIHandler.initialize
 
-.. automethod:: BookstorePublishAPIHandler.post
+.. automethod:: BookstorePublishAPIHandler.put
+
+.. automethod:: BookstorePublishAPIHandler.validate_model
+
+.. automethod:: BookstorePublishAPIHandler.prepare_response


### PR DESCRIPTION
This takes some of the lessons from #139 and applies them to the publish module. 

Most notably it takes as much logic as possible out of the `_publish` method, making it only about speaking to s3 and nothing else.

Also, this moves a lot of the s3 string creation into the base `put` method & simplifies some of the logic that was happening in `prepare_response`.

This needed to build on #140 (since it changed the docstring), so if this is merged, that can be closed.