### PR TITLE
Move async content reading inside s3 client context manager

### DIFF
--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -235,17 +235,9 @@ class TestCloneAPIHandler(AsyncTestCase):
             "path": "test_directory/file_name.txt",
         }
 
-        class MyFakeClass:
-            def __init__(self):
-                pass
-
-            async def read(self):
-                return content.encode('utf-8')
-
-        obj = {'Body': MyFakeClass()}
         path = "test_directory/file_name.txt"
         success_handler = self.post_handler({})
-        model = await success_handler.build_content_model(obj, path)
+        model = success_handler.build_content_model(content, path)
         assert model == expected
 
     @gen_test
@@ -259,15 +251,9 @@ class TestCloneAPIHandler(AsyncTestCase):
             "path": "test_directory/file_name.ipynb",
         }
 
-        class MyFakeClass:
-            def __init__(self):
-                pass
+        str_content = nbformat.writes(content)
 
-            async def read(self):
-                return nbformat.writes(content).encode('utf-8')
-
-        obj = {'Body': MyFakeClass()}
         path = "test_directory/file_name.ipynb"
         success_handler = self.post_handler({})
-        model = await success_handler.build_content_model(obj, path)
+        model = success_handler.build_content_model(str_content, path)
         assert model == expected


### PR DESCRIPTION
This addresses #145 for now. However it does not clarify why the issue arose in the first place.

It is likely that this results in a slightly lower coverage report. 

But, it has some advantages:
1. makes the tests slightly cleaner (since we no longer need to make a class to handle the asynchronous read) 
2. simplifies the API for build_content_model as we now can pass in a string rather than a dict with unused additional fields