### PR TITLE
Update clone handler template

### DIFF
--- a/bookstore/clone.html
+++ b/bookstore/clone.html
@@ -21,10 +21,7 @@ Distributed under the terms of the Modified BSD License.
 
         var button = document.getElementById("mybutton");
         button.onclick = function(event) {
-          var post_json = {
-            s3_bucket: "{{ s3_bucket }}",
-            s3_key: "{{ s3_key }}"
-          };
+          var post_json = {{ post_model | tojson(indent=2)}}
           var xsrf_token = getCookieByName("_xsrf");
           var xhr = new XMLHttpRequest();
           xhr.responseType = "json";
@@ -58,8 +55,8 @@ Distributed under the terms of the Modified BSD License.
 
   <body>
     <p>
-      This is a placeholder for the cloning landing page for the file
-      {{ s3_key }} at {{ s3_bucket }}.
+      This is the landing page where you should confirm that you wish to clone
+      {{ source_description }}.
     </p>
     <button id="mybutton" onclick="alert('did not get replaced')">
       confirm clone

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -132,11 +132,12 @@ class BookstoreCloneHandler(IPythonHandler):
         base_uri = f"{self.request.protocol}://{self.request.host}"
         clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/clone")
         redirect_contents_url = url_path_join(base_uri, self.default_url)
+        model = {"s3_bucket": s3_bucket, "s3_key": s3_object_key}
         template_params = {
-            "s3_bucket": s3_bucket,
-            "s3_key": s3_object_key,
+            "post_model": model,
             "clone_api_url": clone_api_url,
             "redirect_contents_url": redirect_contents_url,
+            "source_description": f"{s3_object_key} from {s3_bucket}",
         }
         return template_params
 

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -94,10 +94,10 @@ class TestCloneHandler(AsyncTestCase):
     def test_gen_template_params(self):
         success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         expected = {
-            's3_bucket': 'hello',
-            's3_key': 'my_key',
+            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key'},
             'clone_api_url': 'https://localhost:8888/api/bookstore/clone',
             'redirect_contents_url': 'https://localhost:8888',
+            'source_description': 'my_key from hello',
         }
         success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         output = success_handler.construct_template_params(
@@ -108,10 +108,10 @@ class TestCloneHandler(AsyncTestCase):
     def test_gen_template_params_base_url(self):
         base_url_list = ['/my_base_url', '/my_base_url/', 'my_base_url/', 'my_base_url']
         expected = {
-            's3_bucket': 'hello',
-            's3_key': 'my_key',
+            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key'},
             'clone_api_url': 'https://localhost:8888/my_base_url/api/bookstore/clone',
             'redirect_contents_url': 'https://localhost:8888',
+            'source_description': 'my_key from hello',
         }
         for base_url in base_url_list:
             mock_app = Mock(


### PR DESCRIPTION
As part of the fs cloning handler, it requires changing how the clone.html template works. This makes it easier to construct a template that works for both handlers.

Main two changes are to move common behaviour to the backend, specifically:

1. creating the post model
2. creating the description of the source file
