### PR TITLE
Validate relpath util

### DIFF
--- a/bookstore/bookstore_config.py
+++ b/bookstore/bookstore_config.py
@@ -36,7 +36,7 @@ class BookstoreSettings(LoggingConfigurable):
     enable_s3_cloning : bool(``True``)
                         Enable cloning from s3.
     fs_cloning_basedir : str(``"/Users/jupyter"``)
-                        Base directory used for relative paths when cloning from the local file system.
+                        Absolute path to base directory used to clone from the local file system
                   
     """
 
@@ -68,7 +68,7 @@ class BookstoreSettings(LoggingConfigurable):
     ).tag(config=True)
 
     fs_cloning_basedir = Unicode(
-        "", help=("Base directory used for relative paths when cloning from the local file system")
+        "", help=("Absolute path to base directory used to clone from the local file system")
     ).tag(config=True)
 
 

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -308,14 +308,17 @@ def validate_relpath(relpath, settings, log):
 
     Parameters
     ----------
-    model : dict
-        Jupyter Contents API model
-    obj : dict
+    relpath : string
+        Relative path to a notebook to be cloned.
+    settings : BookstoreSettings
+        Bookstore configuration.
+    log : logging.Logger
         Log (usually from the NotebookApp) for logging endpoint changes.
-    s3_bucket : str
-        The S3 bucket we are cloning from
-    s3_object_key: str
-        The S3 key we are cloning
+
+    Returns
+    --------
+    Path
+        Absolute path to file to be cloned.
     """
     if relpath == '':
         log.info("Request received with empty relpath.")

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from copy import deepcopy
+from pathlib import Path
 
 import aiobotocore
 
@@ -300,3 +301,21 @@ class BookstoreCloneAPIHandler(APIHandler):
         if 'VersionId' in obj:
             model["versionID"] = obj['VersionId']
         return model
+
+
+def validate_relpath(relpath, settings):
+    """Validates that a relative path appropriately resolves given bookstore settings.
+    """
+    if relpath == '':
+        raise web.HTTPError(400, "Requires a path to clone")
+
+    fs_basedir = Path(settings.fs_cloning_basedir)
+    if not fs_basedir.is_absolute():
+        raise web.HTTPError(400, "File system cloning base directory must be an absolute path")
+
+    fs_clonepath = Path(os.path.realpath(os.path.join(fs_basedir, relpath)))
+
+    if fs_basedir not in fs_clonepath.parents:
+        raise web.HTTPError(400, "Cannot clone from a path outside of the base directory")
+
+    return fs_clonepath

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from unittest.mock import Mock
 from pathlib import Path
@@ -21,6 +22,9 @@ from bookstore.clone import (
     BookstoreCloneAPIHandler,
     validate_relpath,
 )
+
+
+log = logging.getLogger('test_clone')
 
 
 def test_build_notebook_model():
@@ -264,7 +268,7 @@ class TestCloneAPIHandler(AsyncTestCase):
 def test_validate_relpath():
     relpath = 'hi'
     settings = BookstoreSettings(fs_cloning_basedir="/anything")
-    fs_clonepath = validate_relpath(relpath, settings)
+    fs_clonepath = validate_relpath(relpath, settings, log)
     assert fs_clonepath == Path("/anything/hi")
 
 
@@ -272,18 +276,18 @@ def test_validate_relpath_nonabsolute_basedir():
     relpath = 'hi'
     settings = BookstoreSettings(fs_cloning_basedir="anything")
     with pytest.raises(HTTPError):
-        fs_clonepath = validate_relpath(relpath, settings)
+        fs_clonepath = validate_relpath(relpath, settings, log)
 
 
 def test_validate_relpath_empty_relpath():
     relpath = ''
     settings = BookstoreSettings(fs_cloning_basedir="/anything")
     with pytest.raises(HTTPError):
-        fs_clonepath = validate_relpath(relpath, settings)
+        fs_clonepath = validate_relpath(relpath, settings, log)
 
 
 def test_validate_relpath_escape_basedir():
     relpath = '../hi'
     settings = BookstoreSettings(fs_cloning_basedir="/anything")
     with pytest.raises(HTTPError):
-        fs_clonepath = validate_relpath(relpath, settings)
+        fs_clonepath = validate_relpath(relpath, settings, log)

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -272,22 +272,32 @@ def test_validate_relpath():
     assert fs_clonepath == Path("/anything/hi")
 
 
-def test_validate_relpath_nonabsolute_basedir():
+def test_validate_relpath_nonabsolute_basedir(caplog):
     relpath = 'hi'
     settings = BookstoreSettings(fs_cloning_basedir="anything")
     with pytest.raises(HTTPError):
-        fs_clonepath = validate_relpath(relpath, settings, log)
+        with caplog.at_level(logging.INFO):
+            fs_clonepath = validate_relpath(relpath, settings, log)
+
+    assert (
+        f"Bookstore's cloning root directory is set to {settings.fs_cloning_basedir},"
+        in caplog.text
+    )
 
 
-def test_validate_relpath_empty_relpath():
+def test_validate_relpath_empty_relpath(caplog):
     relpath = ''
     settings = BookstoreSettings(fs_cloning_basedir="/anything")
     with pytest.raises(HTTPError):
-        fs_clonepath = validate_relpath(relpath, settings, log)
+        with caplog.at_level(logging.INFO):
+            fs_clonepath = validate_relpath(relpath, settings, log)
+    assert "Request received with empty relpath." in caplog.text
 
 
-def test_validate_relpath_escape_basedir():
+def test_validate_relpath_escape_basedir(caplog):
     relpath = '../hi'
     settings = BookstoreSettings(fs_cloning_basedir="/anything")
     with pytest.raises(HTTPError):
-        fs_clonepath = validate_relpath(relpath, settings, log)
+        with caplog.at_level(logging.INFO):
+            fs_clonepath = validate_relpath(relpath, settings, log)
+    assert f"Request to clone from a path outside of base directory" in caplog.text

--- a/docs/source/reference/clone.rst
+++ b/docs/source/reference/clone.rst
@@ -10,6 +10,8 @@ The ``clone`` module
 
 .. autofunction:: build_file_model
 
+.. autofunction:: validate_relpath
+
 ``BookstoreCloneHandler``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This creates the utility that will be shared between the fs cloning handler & the fs cloning api handler:

- checks the behaviour of the basedir 
- ensures relpath exists 
- ensures relpath does escape out of the basedir