### PR TITLE
Add s3clone integration test

### DIFF
--- a/ci/integration.js
+++ b/ci/integration.js
@@ -64,7 +64,7 @@ const main = async () => {
   await s3Client.makeBucket(bucketName);
   console.log(`Created bucket ${bucketName}`);
 
-  async function compareNotebooks(filepath, originalNotebook) {
+  async function compareS3Notebooks(filepath, originalNotebook) {
     /***** Check notebook from S3 *****/
     const rawNotebook = await s3Client.getObject(
       bucketName,
@@ -199,8 +199,8 @@ const main = async () => {
     await sleep(100);
   }
 
-  function cloneQueryCheck(s3Key, expectedQueryString) {
-    const populatedQueryString = jupyterServer.populateCloneQuery(
+  function s3CloneLandingQueryCheck(s3Key, expectedQueryString) {
+    const populatedQueryString = jupyterServer.populateS3CloneLandingQuery(
       bucketName,
       s3Key
     );
@@ -214,7 +214,7 @@ const main = async () => {
     console.log(`Query matched ${expectedQueryString}`);
   }
 
-  function checkCloneResponse(res, expected) {
+  function checkS3CloneLandingResponse(res, expected) {
     const content = res.response;
     if (!content.includes(expected)) {
       console.error("Response is ill-formed:");
@@ -227,24 +227,26 @@ const main = async () => {
   }
 
   const publishedPath = "ci-published/ci-published.ipynb";
-  cloneQueryCheck(
+  s3CloneLandingQueryCheck(
     publishedPath,
     url_path_join(
       jupyterServer.endpoint,
       `bookstore/clone?s3_bucket=${bucketName}&s3_key=${publishedPath}`
     )
   );
-  const cloneRes = await jupyterServer.cloneNotebook(bucketName, publishedPath);
-  checkCloneResponse(cloneRes, publishedPath);
+  const s3CloneLandingRes = await jupyterServer.cloneS3NotebookLanding(
+    bucketName,
+    publishedPath
+  );
+  checkS3CloneLandingResponse(s3CloneLandingRes, publishedPath);
 
   // Wait for minio to have the notebook
   // Future iterations of this script should poll to get the notebook
   await sleep(700);
 
   jupyterServer.shutdown();
-
-  await compareNotebooks("ci-local-writeout.ipynb", originalNotebook);
-  await compareNotebooks("ci-local-writeout2.ipynb", {
+  await compareS3Notebooks("ci-local-writeout.ipynb", originalNotebook);
+  await compareS3Notebooks("ci-local-writeout2.ipynb", {
     cells: [],
     nbformat: 4,
     nbformat_minor: 2,

--- a/ci/integration.js
+++ b/ci/integration.js
@@ -240,11 +240,12 @@ const main = async () => {
   );
   checkS3CloneLandingResponse(s3CloneLandingRes, publishedPath);
 
+  await jupyterServer.cloneS3Notebook(bucketName, publishedPath);
   // Wait for minio to have the notebook
   // Future iterations of this script should poll to get the notebook
   await sleep(700);
 
-  jupyterServer.shutdown();
+  await compareS3Notebooks("ci-published.ipynb", originalNotebook);
   await compareS3Notebooks("ci-local-writeout.ipynb", originalNotebook);
   await compareS3Notebooks("ci-local-writeout2.ipynb", {
     cells: [],
@@ -254,6 +255,7 @@ const main = async () => {
       save: 3
     }
   });
+  jupyterServer.shutdown();
 
   console.log("📚 Bookstore Integration Complete 📚");
 };

--- a/ci/integration.js
+++ b/ci/integration.js
@@ -255,6 +255,13 @@ const main = async () => {
       save: 3
     }
   });
+  await sleep(700);
+
+  await jupyterServer.deleteNotebook("ci-published.ipynb");
+  await jupyterServer.deleteNotebook("ci-local-writeout.ipynb");
+  await jupyterServer.deleteNotebook("ci-local-writeout2.ipynb");
+  await jupyterServer.deleteNotebook("ci-local-writeout3.ipynb");
+
   jupyterServer.shutdown();
 
   console.log("📚 Bookstore Integration Complete 📚");

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -121,17 +121,17 @@ class JupyterServer {
     return xhr;
   }
 
-  populateCloneQuery(s3Bucket, s3Key) {
+  populateS3CloneLandingQuery(s3Bucket, s3Key) {
     return url_path_join(
       this.endpoint,
       `/bookstore/clone?s3_bucket=${s3Bucket}&s3_key=${s3Key}`
     );
   }
-  async cloneNotebook(s3Bucket, s3Key) {
+  async cloneS3NotebookLanding(s3Bucket, s3Key) {
     // Once https://github.com/nteract/nteract/pull/3651 is merged, we can use
     // rx-jupyter for writing a notebook to the contents API
     const xhr = await ajax({
-      url: this.populateCloneQuery(s3Bucket, s3Key),
+      url: this.populateS3CloneLandingQuery(s3Bucket, s3Key),
       responseType: "text",
       createXHR: () => new XMLHttpRequest(),
       method: "GET",

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -161,6 +161,20 @@ class JupyterServer {
 
     return xhr;
   }
+  async deleteNotebook(path) {
+    const apiPath = "/api/contents/";
+    const xhr = await ajax({
+      url: url_path_join(this.endpoint, apiPath, path),
+      responseType: "json",
+      createXHR: () => new XMLHttpRequest(),
+      method: "DELETE",
+      headers: {
+        Authorization: `token ${this.token}`
+      }
+    }).toPromise();
+
+    return xhr;
+  }
   shutdown() {
     this.process.kill();
   }

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -127,6 +127,9 @@ class JupyterServer {
       `/bookstore/clone?s3_bucket=${s3Bucket}&s3_key=${s3Key}`
     );
   }
+  populateS3CloneQuery() {
+    return url_path_join(this.endpoint, `/api/bookstore/clone`);
+  }
   async cloneS3NotebookLanding(s3Bucket, s3Key) {
     // Once https://github.com/nteract/nteract/pull/3651 is merged, we can use
     // rx-jupyter for writing a notebook to the contents API
@@ -139,6 +142,22 @@ class JupyterServer {
         Authorization: `token ${this.token}`
       }
     }).toPromise();
+
+    return xhr;
+  }
+  async cloneS3Notebook(s3Bucket, s3Key) {
+    const query = {
+      url: this.populateS3CloneQuery(),
+      responseType: "json",
+      createXHR: () => new XMLHttpRequest(),
+      body: { s3_bucket: s3Bucket, s3_key: s3Key },
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `token ${this.token}`
+      }
+    };
+    const xhr = await ajax(query).toPromise();
 
     return xhr;
   }


### PR DESCRIPTION
As I was working on the fs cloning API handler, I realized that we didn't have an integration test for the s3 cloning API handler.

We will need to cleanup the files created by the the cloning APIs, because otherwise we'll create a new file with a new name with each POST request. 

- Adds integration test for the POST handler (checks for the successful match between the published file (on s3), the cloned file (on disk) and the source content) 
- Updates the names to be more specifically about s3 cloning. 
- This also adds a cleanup to the integration tests & cleans up the side-effect notebooks.