### PR TITLE
Add fsclone integration test & format improvements

### DIFF
--- a/bookstore/archive.py
+++ b/bookstore/archive.py
@@ -6,6 +6,7 @@ from typing import Dict
 from typing import NamedTuple
 
 import aiobotocore
+import nbformat
 from notebook.services.contents.filemanager import FileContentsManager
 from tornado import ioloop
 
@@ -151,7 +152,7 @@ class BookstoreContentsArchiver(FileContentsManager):
             )
             return
 
-        content = json.dumps(model["content"])
+        content = nbformat.writes(nbformat.from_dict(model["content"]))
 
         loop = ioloop.IOLoop.current()
 

--- a/bookstore/tests/__init__.py
+++ b/bookstore/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+
+test_dir = os.path.realpath(os.path.dirname(__file__))

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -28,9 +28,10 @@ from bookstore.clone import (
 )
 from bookstore.utils import TemporaryWorkingDirectory
 
+from . import test_dir
+
 
 log = logging.getLogger('test_clone')
-test_dir = os.path.realpath(os.path.dirname(__file__))
 
 
 def test_build_notebook_model():

--- a/ci/integration.js
+++ b/ci/integration.js
@@ -163,6 +163,39 @@ const main = async () => {
     nbformat_minor: 2
   };
 
+  const EmptyNotebook = {
+    cells: [
+      {
+        cell_type: "code",
+        execution_count: null,
+        metadata: {},
+        outputs: [],
+        source: []
+      }
+    ],
+    metadata: {
+      kernelspec: {
+        display_name: "dev",
+        language: "python",
+        name: "dev"
+      },
+      language_info: {
+        codemirror_mode: {
+          name: "ipython",
+          version: 3
+        },
+        file_extension: ".py",
+        mimetype: "text/x-python",
+        name: "python",
+        nbconvert_exporter: "python",
+        pygments_lexer: "ipython3",
+        version: "3.6.8"
+      }
+    },
+    nbformat: 4,
+    nbformat_minor: 2
+  };
+
   await jupyterServer.writeNotebook(
     "ci-local-writeout.ipynb",
     originalNotebook
@@ -241,9 +274,10 @@ const main = async () => {
   checkS3CloneLandingResponse(s3CloneLandingRes, publishedPath);
 
   await jupyterServer.cloneS3Notebook(bucketName, publishedPath);
+  await jupyterServer.cloneFSNotebook("test_files/EmptyNotebook.ipynb");
   // Wait for minio to have the notebook
   // Future iterations of this script should poll to get the notebook
-  await sleep(700);
+  await sleep(2000);
 
   await compareS3Notebooks("ci-published.ipynb", originalNotebook);
   await compareS3Notebooks("ci-local-writeout.ipynb", originalNotebook);
@@ -255,12 +289,15 @@ const main = async () => {
       save: 3
     }
   });
+  await compareS3Notebooks("EmptyNotebook.ipynb", EmptyNotebook);
+
   await sleep(700);
 
   await jupyterServer.deleteNotebook("ci-published.ipynb");
   await jupyterServer.deleteNotebook("ci-local-writeout.ipynb");
   await jupyterServer.deleteNotebook("ci-local-writeout2.ipynb");
   await jupyterServer.deleteNotebook("ci-local-writeout3.ipynb");
+  await jupyterServer.deleteNotebook("EmptyNotebook.ipynb");
 
   jupyterServer.shutdown();
 

--- a/ci/jupyter.js
+++ b/ci/jupyter.js
@@ -161,6 +161,45 @@ class JupyterServer {
 
     return xhr;
   }
+  populateFSCloneLandingQuery(relpath) {
+    return url_path_join(
+      this.endpoint,
+      `/bookstore/fs-clone?relpath=${relpath}`
+    );
+  }
+  populateFSCloneQuery() {
+    return url_path_join(this.endpoint, `/api/bookstore/fs-clone`);
+  }
+  async cloneFSNotebookLanding(relpath) {
+    const xhr = await ajax({
+      url: this.populateFSCloneLandingQuery(relpath),
+      responseType: "text",
+      createXHR: () => new XMLHttpRequest(),
+      method: "GET",
+      headers: {
+        Authorization: `token ${this.token}`
+      }
+    }).toPromise();
+
+    return xhr;
+  }
+  async cloneFSNotebook(relpath) {
+    const query = {
+      url: this.populateFSCloneQuery(),
+      responseType: "json",
+      createXHR: () => new XMLHttpRequest(),
+      body: { relpath },
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `token ${this.token}`
+      }
+    };
+    const xhr = await ajax(query).toPromise();
+
+    return xhr;
+  }
+
   async deleteNotebook(path) {
     const apiPath = "/api/contents/";
     const xhr = await ajax({

--- a/ci/jupyter_notebook_config.py
+++ b/ci/jupyter_notebook_config.py
@@ -4,6 +4,8 @@
 print("using CI config")
 
 from bookstore import BookstoreContentsArchiver, BookstoreSettings
+from bookstore.tests import test_dir
+
 
 # jupyter config
 # At ~/.jupyter/jupyter_notebook_config.py for user installs
@@ -22,3 +24,6 @@ c.BookstoreSettings.s3_bucket = "bookstore"
 # Straight out of `circleci/config.yml`
 c.BookstoreSettings.s3_access_key_id = "ONLY_ON_CIRCLE"
 c.BookstoreSettings.s3_secret_access_key = "CAN_WE_DO_THIS"
+
+# Local filesystem cloning
+c.BookstoreSettings.fs_cloning_basedir = test_dir


### PR DESCRIPTION
This adds integration tests for file system cloning and is based on #162 and #164.

It also required addressing some minor inconsistencies I was discovering when I attempted to try our integration tests with a genuinely empty notebook.

These have to do with how the notebook stores cell `source` values in memory vs. on disk. Because we were using `json.dumps()` to get our to-disk content, we were not always writing out the appropriate information that was being passed through. This was most obvious in the case of an empty source `[]` which was being written to s3 as `''`. 
Using `nbformat.writes` and `nbformat.from_dict` alleviates the issue.

