### PR TITLE
Use paths not fully qualified domain names within bookstore

### DIFF
--- a/bookstore/clone.html
+++ b/bookstore/clone.html
@@ -78,7 +78,7 @@ Distributed under the terms of the Modified BSD License.
           xhr.onload = function(e) {
             if (xhr.readyState === 4) {
               if (xhr.status === 200) {
-                window.location.href = `{{ redirect_contents_url }}/${
+                window.location.pathname = `{{ redirect_contents_url }}/${
                   xhr.response.path
                 }`;
               } else {

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -130,13 +130,13 @@ class BookstoreCloneHandler(IPythonHandler):
         dict
             Template parameters in a dictionary
         """
-        clone_api_url = url_path_join('/', self.base_url, "/api/bookstore/clone")
-        # here we match the logic in how default_url is defined in
+        # here we closely match the logic in how default_url is defined in
         # https://github.com/jupyter/notebook/blob/55e93b9ffef0df9158586e65a34164f7a903e1e0/notebook/notebookapp.py#L1415-L1417
         if self.default_url.startswith(self.base_url):
-            redirect_contents_url = url_path_join('/', self.default_url)
+            redirect_contents_url = self.default_url
         else:
-            redirect_contents_url = url_path_join('/', self.base_url, self.default_url)
+            redirect_contents_url = url_path_join(self.base_url, self.default_url)
+        clone_api_url = url_path_join(self.base_url, "/api/bookstore/clone")
         model = {"s3_bucket": s3_bucket, "s3_key": s3_object_key}
         template_params = {
             "post_model": model,
@@ -394,13 +394,13 @@ class BookstoreFSCloneHandler(IPythonHandler):
         dict
             Template parameters in a dictionary
         """
-        clone_api_url = url_path_join('/', self.base_url, "/api/bookstore/fs-clone")
-        # here we match the logic in how default_url is defined in
+        # here we closely match the logic in how default_url is defined in
         # https://github.com/jupyter/notebook/blob/55e93b9ffef0df9158586e65a34164f7a903e1e0/notebook/notebookapp.py#L1415-L1417
         if self.default_url.startswith(self.base_url):
-            redirect_contents_url = url_path_join('/', self.default_url)
+            redirect_contents_url = self.default_url
         else:
-            redirect_contents_url = url_path_join('/', self.base_url, self.default_url)
+            redirect_contents_url = url_path_join(self.base_url, self.default_url)
+        clone_api_url = url_path_join(self.base_url, "/api/bookstore/fs-clone")
         model = {"relpath": relpath}
 
         template_params = {

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -130,9 +130,13 @@ class BookstoreCloneHandler(IPythonHandler):
         dict
             Template parameters in a dictionary
         """
-        base_uri = f"{self.request.protocol}://{self.request.host}"
-        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/clone")
-        redirect_contents_url = url_path_join(base_uri, self.default_url)
+        clone_api_url = url_path_join('/', self.base_url, "/api/bookstore/clone")
+        # here we match the logic in how default_url is defined in
+        # https://github.com/jupyter/notebook/blob/55e93b9ffef0df9158586e65a34164f7a903e1e0/notebook/notebookapp.py#L1415-L1417
+        if self.default_url.startswith(self.base_url):
+            redirect_contents_url = url_path_join('/', self.default_url)
+        else:
+            redirect_contents_url = url_path_join('/', self.base_url, self.default_url)
         model = {"s3_bucket": s3_bucket, "s3_key": s3_object_key}
         template_params = {
             "post_model": model,
@@ -390,9 +394,13 @@ class BookstoreFSCloneHandler(IPythonHandler):
         dict
             Template parameters in a dictionary
         """
-        base_uri = f"{self.request.protocol}://{self.request.host}"
-        clone_api_url = url_path_join(base_uri, self.base_url, "/api/bookstore/fs-clone")
-        redirect_contents_url = url_path_join(base_uri, self.default_url)
+        clone_api_url = url_path_join('/', self.base_url, "/api/bookstore/fs-clone")
+        # here we match the logic in how default_url is defined in
+        # https://github.com/jupyter/notebook/blob/55e93b9ffef0df9158586e65a34164f7a903e1e0/notebook/notebookapp.py#L1415-L1417
+        if self.default_url.startswith(self.base_url):
+            redirect_contents_url = url_path_join('/', self.default_url)
+        else:
+            redirect_contents_url = url_path_join('/', self.base_url, self.default_url)
         model = {"relpath": relpath}
 
         template_params = {

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -108,8 +108,8 @@ class TestCloneHandler(AsyncTestCase):
         success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         expected = {
             'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key'},
-            'clone_api_url': 'https://localhost:8888/api/bookstore/clone',
-            'redirect_contents_url': 'https://localhost:8888',
+            'clone_api_url': '/api/bookstore/clone',
+            'redirect_contents_url': '/',
             'source_description': "'my_key' from the s3 bucket 'hello'",
         }
         success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
@@ -122,8 +122,8 @@ class TestCloneHandler(AsyncTestCase):
         base_url_list = ['/my_base_url', '/my_base_url/', 'my_base_url/', 'my_base_url']
         expected = {
             'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key'},
-            'clone_api_url': 'https://localhost:8888/my_base_url/api/bookstore/clone',
-            'redirect_contents_url': 'https://localhost:8888',
+            'clone_api_url': '/my_base_url/api/bookstore/clone',
+            'redirect_contents_url': '/my_base_url',
             'source_description': "'my_key' from the s3 bucket 'hello'",
         }
         for base_url in base_url_list:
@@ -348,8 +348,8 @@ class TestFSCloneHandler(AsyncTestCase):
     def test_gen_template_params(self):
         expected = {
             'post_model': {'relpath': 'my/test/path.ipynb'},
-            'clone_api_url': 'https://localhost:8888/api/bookstore/fs-clone',
-            'redirect_contents_url': 'https://localhost:8888',
+            'clone_api_url': '/api/bookstore/fs-clone',
+            'redirect_contents_url': '/',
             'source_description': '/Users/jupyter/my/test/path.ipynb',
         }
         success_handler = self.get_handler('/bookstore/fs-clone?relpath=my/test/path.ipynb')
@@ -362,8 +362,8 @@ class TestFSCloneHandler(AsyncTestCase):
         base_url_list = ['/my_base_url', '/my_base_url/', 'my_base_url/', 'my_base_url']
         expected = {
             'post_model': {'relpath': 'my/test/path.ipynb'},
-            'clone_api_url': 'https://localhost:8888/my_base_url/api/bookstore/fs-clone',
-            'redirect_contents_url': 'https://localhost:8888',
+            'clone_api_url': '/my_base_url/api/bookstore/fs-clone',
+            'redirect_contents_url': '/my_base_url',
             'source_description': '/Users/jupyter/my/test/path.ipynb',
         }
         for base_url in base_url_list:


### PR DESCRIPTION
Currently by creating the entire the entire domain name, our way of constructing urls is not compatible with a bunch of proxy setups. 

Because we're not changing domain/origin with our links we can just use paths to define our redirect location and our api endpoint for the POST.

This switches us to use that logic.

As I went through making that change I discovered that our tests were not actually testing appropriately for the way that `base_url` and `default_url` on the Jupyter server work. 

Because our tests would break when I switched us to using paths, I added the logic needed to match the behaviour expected by the Jupyter server & the Tornado application. 

This primarily consisted of removing any cases where `self.base_url` did not begin and end with "/".  That required
- adding a default `base_url="/"` to all of our test config (to match the code in [notebook/notebookapp.py#L1048-L1062](
https://github.com/jupyter/notebook/blob/f185f4127d0cdfcca501b8c10983c2b23035c3c3/notebook/notebookapp.py#L1048-L1062)
- Dropping the cases of setting `base_url` that did not begin and end with "/".