### PR TITLE
S3 versioned cloning

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,10 @@ version is used.
 
 ## Create the release
 
-- [ ] Update version number `bookstore/_version.py`
+- [ ] Update version numbers in 
+  - [ ] `bookstore/_version.py` (version_info)
+  - [ ] `docs/source/conf.py` (version and release)
+  - [ ] `docs/source/bookstore_api.yaml` (info.version)
 - [ ] Commit the updated version
 - [ ] Clean the repo of all non-tracked files: `git clean -xdfi`
 - [ ] Commit and tag the release

--- a/bookstore/clone.py
+++ b/bookstore/clone.py
@@ -140,11 +140,12 @@ class BookstoreCloneHandler(IPythonHandler):
             redirect_contents_url = url_path_join(self.base_url, self.default_url)
         clone_api_url = url_path_join(self.base_url, "/api/bookstore/clone")
         model = {"s3_bucket": s3_bucket, "s3_key": s3_object_key, "s3_version_id": s3_version_id}
+        version_text = ' version: ' + s3_version_id if s3_version_id else ''
         template_params = {
             "post_model": model,
             "clone_api_url": clone_api_url,
             "redirect_contents_url": redirect_contents_url,
-            "source_description": f"'{s3_object_key}'{' version: '+s3_version_id if s3_version_id else ''} from the s3 bucket '{s3_bucket}'",
+            "source_description": f"'{s3_object_key}'{version_text} from the s3 bucket '{s3_bucket}'",
         }
         return template_params
 

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -121,6 +121,19 @@ class TestCloneHandler(AsyncTestCase):
         )
         assert expected == output
 
+    def test_gen_template_params_s3_version_id(self):
+        expected = {
+            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key', 's3_version_id': "my_version"},
+            'clone_api_url': '/api/bookstore/clone',
+            'redirect_contents_url': '/',
+            'source_description': "'my_key' version: my_version from the s3 bucket 'hello'",
+        }
+        success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key&s3_version_id=my_version')
+        output = success_handler.construct_template_params(
+            s3_bucket="hello", s3_object_key="my_key", s3_version_id="my_version"
+        )
+        assert expected == output
+
     def test_gen_template_params_base_url(self):
         expected = {
             'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key', 's3_version_id': None},

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -109,9 +109,8 @@ class TestCloneHandler(AsyncTestCase):
         await success_handler.get()
 
     def test_gen_template_params(self):
-        success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key')
         expected = {
-            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key'},
+            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key', 's3_version_id': None},
             'clone_api_url': '/api/bookstore/clone',
             'redirect_contents_url': '/',
             'source_description': "'my_key' from the s3 bucket 'hello'",
@@ -124,7 +123,7 @@ class TestCloneHandler(AsyncTestCase):
 
     def test_gen_template_params_base_url(self):
         expected = {
-            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key'},
+            'post_model': {'s3_bucket': 'hello', 's3_key': 'my_key', 's3_version_id': None},
             'clone_api_url': '/my_base_url/api/bookstore/clone',
             'redirect_contents_url': '/my_base_url',
             'source_description': "'my_key' from the s3 bucket 'hello'",

--- a/bookstore/tests/test_clone.py
+++ b/bookstore/tests/test_clone.py
@@ -128,7 +128,9 @@ class TestCloneHandler(AsyncTestCase):
             'redirect_contents_url': '/',
             'source_description': "'my_key' version: my_version from the s3 bucket 'hello'",
         }
-        success_handler = self.get_handler('/bookstore/clone?s3_bucket=hello&s3_key=my_key&s3_version_id=my_version')
+        success_handler = self.get_handler(
+            '/bookstore/clone?s3_bucket=hello&s3_key=my_key&s3_version_id=my_version'
+        )
         output = success_handler.construct_template_params(
             s3_bucket="hello", s3_object_key="my_key", s3_version_id="my_version"
         )
@@ -224,6 +226,33 @@ class TestCloneAPIHandler(AsyncTestCase):
         success_handler = self.post_handler(post_body_dict)
         with pytest.raises(HTTPError):
             await success_handler._clone(s3_bucket, s3_object_key)
+
+    def test_build_s3_request_object(self):
+        expected = {"Bucket": "my_bucket", "Key": "my_key"}
+        s3_bucket = "my_bucket"
+        s3_object_key = "my_key"
+        post_body_dict = {"s3_key": "my_key", "s3_bucket": "my_bucket"}
+        success_handler = self.post_handler(post_body_dict)
+        actual = success_handler._build_s3_request_object(s3_bucket, s3_object_key)
+        assert actual == expected
+
+    def test_build_s3_request_object_version_id(self):
+        expected = {"Bucket": "my_bucket", "Key": "my_key", "VersionId": "my_version"}
+
+        s3_bucket = "my_bucket"
+        s3_object_key = "my_key"
+        s3_version_id = "my_version"
+
+        post_body_dict = {
+            "s3_key": s3_object_key,
+            "s3_bucket": s3_bucket,
+            "s3_version_id": s3_version_id,
+        }
+        success_handler = self.post_handler(post_body_dict)
+        actual = success_handler._build_s3_request_object(
+            s3_bucket, s3_object_key, s3_version_id=s3_version_id
+        )
+        assert actual == expected
 
     def test_build_post_response_model(self):
         content = "some arbitrary content"

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: BSD 3-clause
     url: https://github.com/nteract/bookstore/blob/master/LICENSE 
-  version: 2.5.1
+  version: 2.5.1dev0
 externalDocs:
   description: Find out more about Bookstore
   url: https://bookstore.readthedocs.io/en/latest/ 

--- a/docs/source/bookstore_api.yaml
+++ b/docs/source/bookstore_api.yaml
@@ -9,7 +9,7 @@ info:
   license:
     name: BSD 3-clause
     url: https://github.com/nteract/bookstore/blob/master/LICENSE 
-  version: 2.3.0.dev0
+  version: 2.5.1
 externalDocs:
   description: Find out more about Bookstore
   url: https://bookstore.readthedocs.io/en/latest/ 
@@ -44,6 +44,13 @@ paths:
         in: query
         description: S3 object key being requested
         required: true
+        style: form
+        schema:
+          type: string
+      - name: s3_version_id
+        in: query
+        description: S3 object key being requested
+        required: false
         style: form
         schema:
           type: string
@@ -170,6 +177,8 @@ components:
         s3_bucket: 
           type: string
         s3_key:
+          type: string
+        s3_version_id:
           type: string
         target_path:
           type: string


### PR DESCRIPTION
This adds the ability to clone an old version from a versioned s3 bucket. 

Addresses #172 

Unfortunately we cannot test for this functionality in our minio based integration tests. This is because minio does not support versioned buckets:
see https://github.com/minio/minio/pull/6494 for the latest efforts to implement ending in a decision to not do so and https://github.com/minio/minio/issues/1309 for some of the original discussion around it.

This pulls out functionality around creating the kwargs to send to S3 so that we can test that logic independently.

This also updates the API docs.

@MSeal @captainsafia I added you as reviewers per your request earlier today at the team meeting.